### PR TITLE
Fix Codex headless prompt handling on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrus"
-version = "0.2.5-alpha.9"
+version = "0.2.5-alpha.10"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrus"
-version = "0.2.5-alpha.9"
+version = "0.2.5-alpha.10"
 edition = "2024"
 rust-version = "1.95.0"
 license = "Apache-2.0"

--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -14,8 +14,6 @@ const EXECUTABLE: &str = "codex";
 /// On Windows, npm-style shims are commonly installed as `*.cmd`.
 #[cfg(windows)]
 const EXECUTABLE: &str = "codex.cmd";
-#[cfg(windows)]
-const WINDOWS_SHELL: &str = "cmd";
 
 /// Interactive and headless supervisor launcher for the Codex CLI.
 #[derive(Debug, Clone)]
@@ -79,22 +77,6 @@ impl ExecutorAgent for Executor {
 
 #[inline(always)]
 fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
-    #[cfg(windows)]
-    if let AgentRunMode::Headless { prompt } = mode {
-        // On Windows, launching `codex exec` through `cmd /C` mirrors the
-        // successful manual terminal path more closely than direct `.cmd`
-        // process spawning under Ferrus.
-        let mut cmd = Command::new(WINDOWS_SHELL);
-        // `/D /S /C` keeps the shell invocation deterministic for quoted args
-        // and prevents AutoRun hooks from affecting non-interactive launches.
-        cmd.arg("/D").arg("/S").arg("/C").arg("codex").arg("exec");
-        if let Some(model) = model {
-            cmd.arg("--model").arg(model);
-        }
-        cmd.arg(prompt);
-        return cmd;
-    }
-
     let mut cmd = Command::new(EXECUTABLE);
     match mode {
         AgentRunMode::Interactive { prompt } => {
@@ -112,7 +94,17 @@ fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
             if let Some(model) = model {
                 cmd.arg("--model").arg(model);
             }
-            cmd.arg(prompt);
+            #[cfg(windows)]
+            {
+                // On Windows, Ferrus streams the prompt via stdin to avoid
+                // multi-line argv transport issues through shell shims.
+                let _ = prompt;
+                cmd.arg("-");
+            }
+            #[cfg(not(windows))]
+            {
+                cmd.arg(prompt);
+            }
         }
     }
     cmd
@@ -147,10 +139,14 @@ mod tests {
     #[test]
     fn codex_model_override_is_part_of_spawned_command() {
         let agent = Executor::new(Some("gpt-5.4"));
+        #[cfg(windows)]
+        let expected: &[&str] = &["exec", "--model", "gpt-5.4", "-"];
+        #[cfg(not(windows))]
+        let expected: &[&str] = &["exec", "--model", "gpt-5.4", "run"];
         assert_program_and_args(
             agent.spawn(AgentRunMode::Headless { prompt: "run" }),
             EXECUTABLE,
-            &["exec", "--model", "gpt-5.4", "run"],
+            expected,
         );
     }
 
@@ -201,14 +197,14 @@ mod tests {
     }
     #[cfg(windows)]
     #[test]
-    fn codex_headless_command_uses_cmd_wrapper_on_windows() {
+    fn codex_headless_command_uses_stdin_prompt_on_windows() {
         let agent = Executor::new(None);
         assert_program_and_args(
             agent.spawn(AgentRunMode::Headless {
                 prompt: "line one\n\nline two",
             }),
-            WINDOWS_SHELL,
-            &["/D", "/S", "/C", "codex", "exec", "line one\n\nline two"],
+            EXECUTABLE,
+            &["exec", "-"],
         );
     }
 

--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -14,6 +14,8 @@ const EXECUTABLE: &str = "codex";
 /// On Windows, npm-style shims are commonly installed as `*.cmd`.
 #[cfg(windows)]
 const EXECUTABLE: &str = "codex.cmd";
+#[cfg(windows)]
+const WINDOWS_SHELL: &str = "cmd";
 
 /// Interactive and headless supervisor launcher for the Codex CLI.
 #[derive(Debug, Clone)]
@@ -77,6 +79,20 @@ impl ExecutorAgent for Executor {
 
 #[inline(always)]
 fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
+    #[cfg(windows)]
+    if let AgentRunMode::Headless { prompt } = mode {
+        // On Windows, launching `codex exec` through `cmd /C` mirrors the
+        // successful manual terminal path more closely than direct `.cmd`
+        // process spawning under Ferrus.
+        let mut cmd = Command::new(WINDOWS_SHELL);
+        cmd.arg("/C").arg("codex").arg("exec");
+        if let Some(model) = model {
+            cmd.arg("--model").arg(model);
+        }
+        cmd.arg(prompt);
+        return cmd;
+    }
+
     let mut cmd = Command::new(EXECUTABLE);
     match mode {
         AgentRunMode::Interactive { prompt } => {
@@ -94,25 +110,10 @@ fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
             if let Some(model) = model {
                 cmd.arg("--model").arg(model);
             }
-            cmd.arg(headless_prompt_arg(prompt));
+            cmd.arg(prompt);
         }
     }
     cmd
-}
-
-#[cfg(windows)]
-fn headless_prompt_arg(prompt: &str) -> String {
-    // Codex is frequently installed via an npm shim (`codex.cmd`) on Windows.
-    // Multi-line argv values can be mangled by cmd argument handling, causing
-    // `codex exec` to exit before any logs are produced. Encode line breaks as
-    // literal `\n` markers so transport stays single-line without dropping
-    // blank lines or indentation semantics from the original prompt.
-    prompt.replace("\r\n", "\n").replace('\n', "\\n")
-}
-
-#[cfg(not(windows))]
-fn headless_prompt_arg(prompt: &str) -> &str {
-    prompt
 }
 
 #[cfg(test)]
@@ -198,14 +199,14 @@ mod tests {
     }
     #[cfg(windows)]
     #[test]
-    fn codex_headless_prompt_is_flattened_on_windows() {
+    fn codex_headless_command_uses_cmd_wrapper_on_windows() {
         let agent = Executor::new(None);
         assert_program_and_args(
             agent.spawn(AgentRunMode::Headless {
                 prompt: "line one\n\nline two",
             }),
-            EXECUTABLE,
-            &["exec", "line one\\n\\nline two"],
+            WINDOWS_SHELL,
+            &["/C", "codex", "exec", "line one\n\nline two"],
         );
     }
 

--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -94,10 +94,29 @@ fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
             if let Some(model) = model {
                 cmd.arg("--model").arg(model);
             }
-            cmd.arg(prompt);
+            cmd.arg(headless_prompt_arg(prompt));
         }
     }
     cmd
+}
+
+#[cfg(windows)]
+fn headless_prompt_arg(prompt: &str) -> String {
+    // Codex is frequently installed via an npm shim (`codex.cmd`) on Windows.
+    // Multi-line argv values can be mangled by cmd argument handling, causing
+    // `codex exec` to exit before any logs are produced. Flatten line breaks to
+    // preserve content while keeping the command-line transport robust.
+    prompt
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(not(windows))]
+fn headless_prompt_arg(prompt: &str) -> &str {
+    prompt
 }
 
 #[cfg(test)]
@@ -180,5 +199,30 @@ mod tests {
             .collect::<Vec<_>>()
         );
         assert_eq!(entry.model, None);
+    }
+    #[cfg(windows)]
+    #[test]
+    fn codex_headless_prompt_is_flattened_on_windows() {
+        let agent = Executor::new(None);
+        assert_program_and_args(
+            agent.spawn(AgentRunMode::Headless {
+                prompt: "line one\n\nline two",
+            }),
+            EXECUTABLE,
+            &["exec", "line one\nline two"],
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn codex_headless_prompt_preserves_newlines_off_windows() {
+        let agent = Executor::new(None);
+        assert_program_and_args(
+            agent.spawn(AgentRunMode::Headless {
+                prompt: "line one\n\nline two",
+            }),
+            EXECUTABLE,
+            &["exec", "line one\n\nline two"],
+        );
     }
 }

--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -3,7 +3,9 @@
 //! These wrappers isolate the CLI details needed to launch Codex in the shapes
 //! Ferrus expects for interactive and headless sessions.
 
-use super::{AgentRunMode, ExecutorAgent, SupervisorAgent, normalized_model};
+use super::{
+    AgentRunMode, ExecutorAgent, HeadlessPromptTransport, SupervisorAgent, normalized_model,
+};
 use std::process::Command;
 
 /// Stable agent identifier used in Ferrus configuration and error messages.
@@ -57,6 +59,17 @@ impl SupervisorAgent for Supervisor {
     fn model(&self) -> Option<&str> {
         self.model.as_deref()
     }
+
+    fn headless_prompt_transport(&self) -> HeadlessPromptTransport {
+        #[cfg(windows)]
+        {
+            HeadlessPromptTransport::Stdin
+        }
+        #[cfg(not(windows))]
+        {
+            HeadlessPromptTransport::Argv
+        }
+    }
 }
 
 impl ExecutorAgent for Executor {
@@ -72,6 +85,17 @@ impl ExecutorAgent for Executor {
 
     fn model(&self) -> Option<&str> {
         self.model.as_deref()
+    }
+
+    fn headless_prompt_transport(&self) -> HeadlessPromptTransport {
+        #[cfg(windows)]
+        {
+            HeadlessPromptTransport::Stdin
+        }
+        #[cfg(not(windows))]
+        {
+            HeadlessPromptTransport::Argv
+        }
     }
 }
 
@@ -218,6 +242,32 @@ mod tests {
             }),
             EXECUTABLE,
             &["exec", "line one\n\nline two"],
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn codex_uses_stdin_prompt_transport_on_windows() {
+        assert_eq!(
+            Executor::new(None).headless_prompt_transport(),
+            HeadlessPromptTransport::Stdin
+        );
+        assert_eq!(
+            Supervisor::new(None).headless_prompt_transport(),
+            HeadlessPromptTransport::Stdin
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn codex_uses_argv_prompt_transport_off_windows() {
+        assert_eq!(
+            Executor::new(None).headless_prompt_transport(),
+            HeadlessPromptTransport::Argv
+        );
+        assert_eq!(
+            Supervisor::new(None).headless_prompt_transport(),
+            HeadlessPromptTransport::Argv
         );
     }
 }

--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -104,14 +104,10 @@ fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
 fn headless_prompt_arg(prompt: &str) -> String {
     // Codex is frequently installed via an npm shim (`codex.cmd`) on Windows.
     // Multi-line argv values can be mangled by cmd argument handling, causing
-    // `codex exec` to exit before any logs are produced. Flatten line breaks to
-    // preserve content while keeping the command-line transport robust.
-    prompt
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .collect::<Vec<_>>()
-        .join("\n")
+    // `codex exec` to exit before any logs are produced. Encode line breaks as
+    // literal `\n` markers so transport stays single-line without dropping
+    // blank lines or indentation semantics from the original prompt.
+    prompt.replace("\r\n", "\n").replace('\n', "\\n")
 }
 
 #[cfg(not(windows))]
@@ -209,7 +205,7 @@ mod tests {
                 prompt: "line one\n\nline two",
             }),
             EXECUTABLE,
-            &["exec", "line one\nline two"],
+            &["exec", "line one\\n\\nline two"],
         );
     }
 

--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -61,14 +61,7 @@ impl SupervisorAgent for Supervisor {
     }
 
     fn headless_prompt_transport(&self) -> HeadlessPromptTransport {
-        #[cfg(windows)]
-        {
-            HeadlessPromptTransport::Stdin
-        }
-        #[cfg(not(windows))]
-        {
-            HeadlessPromptTransport::Argv
-        }
+        codex_headless_prompt_transport()
     }
 }
 
@@ -88,14 +81,7 @@ impl ExecutorAgent for Executor {
     }
 
     fn headless_prompt_transport(&self) -> HeadlessPromptTransport {
-        #[cfg(windows)]
-        {
-            HeadlessPromptTransport::Stdin
-        }
-        #[cfg(not(windows))]
-        {
-            HeadlessPromptTransport::Argv
-        }
+        codex_headless_prompt_transport()
     }
 }
 
@@ -120,10 +106,17 @@ fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
             }
             #[cfg(windows)]
             {
-                // On Windows, Ferrus streams the prompt via stdin to avoid
-                // multi-line argv transport issues through shell shims.
+                // Keep this in sync with `codex_headless_prompt_transport()`.
+                // When transport is `Stdin`, Codex must receive `-` sentinel.
                 let _ = prompt;
-                cmd.arg("-");
+                match codex_headless_prompt_transport() {
+                    HeadlessPromptTransport::Stdin => {
+                        cmd.arg("-");
+                    }
+                    HeadlessPromptTransport::Argv => {
+                        cmd.arg(prompt);
+                    }
+                }
             }
             #[cfg(not(windows))]
             {
@@ -132,6 +125,17 @@ fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
         }
     }
     cmd
+}
+
+fn codex_headless_prompt_transport() -> HeadlessPromptTransport {
+    #[cfg(windows)]
+    {
+        HeadlessPromptTransport::Stdin
+    }
+    #[cfg(not(windows))]
+    {
+        HeadlessPromptTransport::Argv
+    }
 }
 
 #[cfg(test)]

--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -85,7 +85,9 @@ fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
         // successful manual terminal path more closely than direct `.cmd`
         // process spawning under Ferrus.
         let mut cmd = Command::new(WINDOWS_SHELL);
-        cmd.arg("/C").arg("codex").arg("exec");
+        // `/D /S /C` keeps the shell invocation deterministic for quoted args
+        // and prevents AutoRun hooks from affecting non-interactive launches.
+        cmd.arg("/D").arg("/S").arg("/C").arg("codex").arg("exec");
         if let Some(model) = model {
             cmd.arg("--model").arg(model);
         }
@@ -206,7 +208,7 @@ mod tests {
                 prompt: "line one\n\nline two",
             }),
             WINDOWS_SHELL,
-            &["/C", "codex", "exec", "line one\n\nline two"],
+            &["/D", "/S", "/C", "codex", "exec", "line one\n\nline two"],
         );
     }
 

--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -157,10 +157,14 @@ mod tests {
     #[test]
     fn codex_executor_builds_headless_command() {
         let agent = Executor::new(None);
+        #[cfg(windows)]
+        let expected: &[&str] = &["exec", "-"];
+        #[cfg(not(windows))]
+        let expected: &[&str] = &["exec", "run"];
         assert_program_and_args(
             agent.spawn(AgentRunMode::Headless { prompt: "run" }),
             EXECUTABLE,
-            &["exec", "run"],
+            expected,
         );
     }
 

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -32,6 +32,15 @@ pub enum AgentRunMode<'a> {
     Headless { prompt: &'a str },
 }
 
+/// Declares how a headless prompt should be transported to the child process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HeadlessPromptTransport {
+    /// Pass prompt as a regular CLI argument.
+    Argv,
+    /// Pass prompt via stdin and close stdin after writing.
+    Stdin,
+}
+
 /// Behavior required from a supervisor-capable agent implementation.
 ///
 /// Supervisor agents support both interactive sessions for humans and
@@ -63,6 +72,11 @@ pub trait SupervisorAgent: Send + Sync {
 
     /// Returns the optional model override used by this backend.
     fn model(&self) -> Option<&str>;
+
+    /// Describes how headless prompt text should be delivered.
+    fn headless_prompt_transport(&self) -> HeadlessPromptTransport {
+        HeadlessPromptTransport::Argv
+    }
 }
 
 /// Behavior required from an executor-capable agent implementation.
@@ -92,6 +106,11 @@ pub trait ExecutorAgent: Send + Sync {
 
     /// Returns the optional model override used by this backend.
     fn model(&self) -> Option<&str>;
+
+    /// Describes how headless prompt text should be delivered.
+    fn headless_prompt_transport(&self) -> HeadlessPromptTransport {
+        HeadlessPromptTransport::Argv
+    }
 }
 
 /// Parses a configured supervisor agent name into its concrete implementation.

--- a/src/hq/agent_manager.rs
+++ b/src/hq/agent_manager.rs
@@ -327,14 +327,24 @@ async fn spawn_headless(
         let log_stderr = log_file
             .try_clone()
             .context("Failed to clone log file handle")?;
+        let stdin = if use_stdin_prompt_transport(agent_type) {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        };
         command
-            .stdin(Stdio::null())
+            .stdin(stdin)
             .stdout(Stdio::from(log_file))
             .stderr(Stdio::from(log_stderr));
         None
     } else {
+        let stdin = if use_stdin_prompt_transport(agent_type) {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        };
         command
-            .stdin(Stdio::null())
+            .stdin(stdin)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
         Some(Arc::new(Mutex::new(SlimLogger::new(log_file))))
@@ -350,6 +360,9 @@ async fn spawn_headless(
             log_path.display()
         )
     })?;
+    if use_stdin_prompt_transport(agent_type) {
+        stream_prompt_to_stdin(&mut child, prompt).context("Failed to stream initial prompt")?;
+    }
 
     let pid = child.id();
     let platform_guard = match platform::attach_headless_process(pid) {
@@ -433,6 +446,30 @@ async fn spawn_headless(
         wait_thread: Some(wait_thread),
         output_threads,
     })
+}
+
+#[cfg(windows)]
+fn use_stdin_prompt_transport(agent_type: &str) -> bool {
+    agent_type == "codex"
+}
+
+#[cfg(not(windows))]
+fn use_stdin_prompt_transport(_agent_type: &str) -> bool {
+    false
+}
+
+fn stream_prompt_to_stdin(child: &mut std::process::Child, prompt: &str) -> Result<()> {
+    use std::io::Write as _;
+
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("stdin pipe is unavailable"))?;
+    stdin
+        .write_all(prompt.as_bytes())
+        .context("failed writing prompt to stdin")?;
+    drop(stdin);
+    Ok(())
 }
 
 fn append_debug_agent_flags(agent_type: &str, command: &mut StdCommand) {
@@ -693,5 +730,17 @@ mod tests {
             codex.get_args().next().is_none(),
             "codex should not receive an extra debug flag when none is supported"
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_codex_headless_uses_stdin_transport() {
+        assert!(use_stdin_prompt_transport("codex"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn non_windows_codex_headless_does_not_use_stdin_transport() {
+        assert!(!use_stdin_prompt_transport("codex"));
     }
 }

--- a/src/hq/agent_manager.rs
+++ b/src/hq/agent_manager.rs
@@ -1,5 +1,5 @@
 use crate::agent_id::{ROLE_EXECUTOR, ROLE_SUPERVISOR};
-use crate::agents::{AgentRunMode, ExecutorAgent, SupervisorAgent};
+use crate::agents::{AgentRunMode, ExecutorAgent, HeadlessPromptTransport, SupervisorAgent};
 use crate::platform::{self, ShutdownSignal};
 use crate::state::agents::{AgentEntry, AgentStatus, read_agents, write_agents};
 use anyhow::{Context, Result};
@@ -285,7 +285,16 @@ pub async fn spawn_headless_executor(
     debug: bool,
 ) -> Result<HeadlessHandle> {
     let command = agent.spawn(AgentRunMode::Headless { prompt });
-    spawn_headless(agent.name(), command, ROLE_EXECUTOR, name, prompt, debug).await
+    spawn_headless(
+        agent.name(),
+        command,
+        agent.headless_prompt_transport(),
+        ROLE_EXECUTOR,
+        name,
+        prompt,
+        debug,
+    )
+    .await
 }
 
 pub async fn spawn_headless_supervisor(
@@ -295,12 +304,22 @@ pub async fn spawn_headless_supervisor(
     debug: bool,
 ) -> Result<HeadlessHandle> {
     let command = agent.spawn(AgentRunMode::Headless { prompt });
-    spawn_headless(agent.name(), command, ROLE_SUPERVISOR, name, prompt, debug).await
+    spawn_headless(
+        agent.name(),
+        command,
+        agent.headless_prompt_transport(),
+        ROLE_SUPERVISOR,
+        name,
+        prompt,
+        debug,
+    )
+    .await
 }
 
 async fn spawn_headless(
     agent_type: &str,
     mut command: StdCommand,
+    prompt_transport: HeadlessPromptTransport,
     role: &str,
     name: &str,
     prompt: &str,
@@ -327,7 +346,7 @@ async fn spawn_headless(
         let log_stderr = log_file
             .try_clone()
             .context("Failed to clone log file handle")?;
-        let stdin = if use_stdin_prompt_transport(agent_type) {
+        let stdin = if prompt_transport == HeadlessPromptTransport::Stdin {
             Stdio::piped()
         } else {
             Stdio::null()
@@ -338,7 +357,7 @@ async fn spawn_headless(
             .stderr(Stdio::from(log_stderr));
         None
     } else {
-        let stdin = if use_stdin_prompt_transport(agent_type) {
+        let stdin = if prompt_transport == HeadlessPromptTransport::Stdin {
             Stdio::piped()
         } else {
             Stdio::null()
@@ -360,7 +379,7 @@ async fn spawn_headless(
             log_path.display()
         )
     })?;
-    if use_stdin_prompt_transport(agent_type) {
+    if prompt_transport == HeadlessPromptTransport::Stdin {
         stream_prompt_to_stdin(&mut child, prompt).context("Failed to stream initial prompt")?;
     }
 
@@ -446,16 +465,6 @@ async fn spawn_headless(
         wait_thread: Some(wait_thread),
         output_threads,
     })
-}
-
-#[cfg(windows)]
-fn use_stdin_prompt_transport(agent_type: &str) -> bool {
-    agent_type == "codex"
-}
-
-#[cfg(not(windows))]
-fn use_stdin_prompt_transport(_agent_type: &str) -> bool {
-    false
 }
 
 fn stream_prompt_to_stdin(child: &mut std::process::Child, prompt: &str) -> Result<()> {
@@ -730,17 +739,5 @@ mod tests {
             codex.get_args().next().is_none(),
             "codex should not receive an extra debug flag when none is supported"
         );
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn windows_codex_headless_uses_stdin_transport() {
-        assert!(use_stdin_prompt_transport("codex"));
-    }
-
-    #[cfg(not(windows))]
-    #[test]
-    fn non_windows_codex_headless_does_not_use_stdin_transport() {
-        assert!(!use_stdin_prompt_transport("codex"));
     }
 }


### PR DESCRIPTION
### Motivation
- Headless `codex exec` launched via `codex.cmd` on Windows can mishandle multi-line argv values, causing the Codex executor to fail to start under Ferrus and produce no logs.

### Description
- Use a helper `headless_prompt_arg(prompt)` in the Codex headless command construction instead of passing the raw `prompt` string.
- Implement `headless_prompt_arg` as a Windows-specific `String` that trims lines, removes empty lines, and joins them with `\n` to produce a robust single-argument payload for `codex.cmd`.
- Provide a `#[cfg(not(windows))]` no-op implementation that returns `&str` so non-Windows behavior is unchanged.
- Add unit tests `codex_headless_prompt_is_flattened_on_windows` and `codex_headless_prompt_preserves_newlines_off_windows` in `src/agents/codex/mod.rs` to document and verify platform-specific behavior.

### Testing
- Ran `cargo fmt --check` which passed after applying formatting changes.
- Ran `cargo clippy -- -D warnings` but it could not complete in this environment due to the local `rustc` being `1.92.0` while the project requires `1.95.0`.
- Ran `cargo test` but it could not complete for the same toolchain mismatch, so the new unit tests were added but not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8901eaeb08332bfb217e44c5c1951)