### PR TITLE
Windows: prevent child console inheritance (CREATE_NO_WINDOW)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrus"
-version = "0.2.5-alpha.10"
+version = "0.2.5-alpha.11"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrus"
-version = "0.2.5-alpha.10"
+version = "0.2.5-alpha.11"
 edition = "2024"
 rust-version = "1.95.0"
 license = "Apache-2.0"

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -14,8 +14,8 @@ use windows_sys::Win32::System::JobObjects::{
     SetInformationJobObject,
 };
 use windows_sys::Win32::System::Threading::{
-    OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SET_QUOTA, PROCESS_TERMINATE,
-    TerminateProcess, WaitForSingleObject,
+    CREATE_NO_WINDOW, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SET_QUOTA,
+    PROCESS_TERMINATE, TerminateProcess, WaitForSingleObject,
 };
 
 // Win32 SYNCHRONIZE access right used for WaitForSingleObject on process handles.
@@ -25,7 +25,14 @@ pub(crate) fn set_serve_process_name() {}
 
 pub(crate) fn install_serve_parent_lifecycle_hooks() {}
 
-pub(crate) fn configure_headless_command(_command: &mut StdCommand) {}
+pub(crate) fn configure_headless_command(command: &mut StdCommand) {
+    use std::os::windows::process::CommandExt;
+
+    // Headless agents should not inherit HQ's console on Windows.
+    // Detached console state prevents child CLIs from mutating input modes
+    // (focus reporting, bracketed paste, mouse tracking) seen by HQ.
+    command.creation_flags(CREATE_NO_WINDOW);
+}
 
 pub(crate) struct HeadlessProcessGuard(HANDLE);
 


### PR DESCRIPTION
### Motivation
- Prevent headless child agents on Windows from inheriting the parent's console so they cannot mutate shared input modes or interfere with HQ's terminal state.
- Bump package version to `0.2.5-alpha.11` to reflect the change.

### Description
- Implement `configure_headless_command` to set `creation_flags(CREATE_NO_WINDOW)` on `StdCommand` and import `CommandExt` so headless children do not inherit the console.
- Add `CREATE_NO_WINDOW` to the Windows threading imports and update related module code formatting.
- Update `Cargo.toml` and `Cargo.lock` to bump the `ferrus` package version from `0.2.5-alpha.10` to `0.2.5-alpha.11`.

### Testing
- Ran `cargo build` to verify the project compiles successfully and the change to Windows-specific code does not break cross-platform builds; build succeeded.
- Ran `cargo test` to exercise the test suite and ensure no regressions; tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea218e3dd883329b556f520c7b556f)