### PR TITLE
Reset Windows terminal input reporting modes and bump ferrus to 0.2.5-alpha.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrus"
-version = "0.2.5-alpha.11"
+version = "0.2.5-alpha.12"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrus"
-version = "0.2.5-alpha.11"
+version = "0.2.5-alpha.12"
 edition = "2024"
 rust-version = "1.95.0"
 license = "Apache-2.0"

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1,4 +1,7 @@
-use std::{io::Stdout, process::Command as StdCommand};
+use std::{
+    io::{Stdout, Write},
+    process::Command as StdCommand,
+};
 
 use super::ShutdownSignal;
 use anyhow::{Context, Result};
@@ -14,8 +17,8 @@ use windows_sys::Win32::System::JobObjects::{
     SetInformationJobObject,
 };
 use windows_sys::Win32::System::Threading::{
-    CREATE_NO_WINDOW, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SET_QUOTA,
-    PROCESS_TERMINATE, TerminateProcess, WaitForSingleObject,
+    OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SET_QUOTA, PROCESS_TERMINATE,
+    TerminateProcess, WaitForSingleObject,
 };
 
 // Win32 SYNCHRONIZE access right used for WaitForSingleObject on process handles.
@@ -26,12 +29,7 @@ pub(crate) fn set_serve_process_name() {}
 pub(crate) fn install_serve_parent_lifecycle_hooks() {}
 
 pub(crate) fn configure_headless_command(command: &mut StdCommand) {
-    use std::os::windows::process::CommandExt;
-
-    // Headless agents should not inherit HQ's console on Windows.
-    // Detached console state prevents child CLIs from mutating input modes
-    // (focus reporting, bracketed paste, mouse tracking) seen by HQ.
-    command.creation_flags(CREATE_NO_WINDOW);
+    let _ = command;
 }
 
 pub(crate) struct HeadlessProcessGuard(HANDLE);
@@ -114,9 +112,23 @@ pub(crate) fn flush_stdin_input_buffer() {
     }
 }
 
-pub(crate) fn enter_tui(_stdout: &mut Stdout) {}
+pub(crate) fn enter_tui(stdout: &mut Stdout) {
+    reset_console_input_reporting_modes(stdout);
+}
 
-pub(crate) fn leave_tui(_stdout: &mut Stdout) {}
+pub(crate) fn leave_tui(stdout: &mut Stdout) {
+    reset_console_input_reporting_modes(stdout);
+}
+
+fn reset_console_input_reporting_modes(stdout: &mut Stdout) {
+    // Best-effort cleanup for terminals that keep DEC private modes enabled
+    // after a child process exits. In ConPTY this can surface focus/mouse/
+    // bracketed-paste reports as literal key input once HQ resumes.
+    const RESET_MODES: &[u8] =
+        b"\x1b[?1004l\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l\x1b[?2004l";
+    let _ = stdout.write_all(RESET_MODES);
+    let _ = stdout.flush();
+}
 
 fn with_process_handle<T>(pid: u32, access: u32, f: impl FnOnce(HANDLE) -> T) -> Option<T> {
     let handle = unsafe { OpenProcess(access, 0, pid) };


### PR DESCRIPTION
### Motivation
- Fix lingering DEC private mode state (focus/mouse/bracketed paste) that can appear as literal key input after headless child processes exit on Windows.
- Prepare a new patch release by updating the package version to `0.2.5-alpha.12`.

### Description
- Bumped package version in `Cargo.toml` and `Cargo.lock` from `0.2.5-alpha.11` to `0.2.5-alpha.12`.
- Reworked Windows platform handling by making `configure_headless_command` a no-op and removing the previous `CREATE_NO_WINDOW` creation flag usage.
- Added `enter_tui` and `leave_tui` implementations that call a new helper `reset_console_input_reporting_modes` which writes DEC private-mode reset ANSI sequences to the provided `Stdout` and flushes it.
- Updated imports to include `Write` and cleaned up unused imports in `src/platform/windows.rs`.

### Testing
- Ran `cargo build` to ensure the workspace compiles successfully and the build succeeded.
- Ran `cargo test` to execute unit tests and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1f38c3bc8332a4bcd120b1b107a3)