### PR TITLE
Spec command + QoL improvements

### DIFF
--- a/.agents/skills/ferrus-supervisor/SKILL.md
+++ b/.agents/skills/ferrus-supervisor/SKILL.md
@@ -35,6 +35,7 @@ Runtime workflow is defined by the initial prompt and Ferrus MCP tools.
 ## Useful Ferrus tools
 
 - `/create_task`
+- `/create_spec`
 - `/wait_for_review`
 - `/review_pending`
 - `/approve`
@@ -45,6 +46,7 @@ Runtime workflow is defined by the initial prompt and Ferrus MCP tools.
 ## Useful Ferrus resources
 
 - `ferrus://task`
+- `ferrus://spec_template`
 - `ferrus://submission`
 - `ferrus://review`
 - `ferrus://consult_request`

--- a/.agents/skills/ferrus/SKILL.md
+++ b/.agents/skills/ferrus/SKILL.md
@@ -62,6 +62,7 @@ Set `RUST_LOG=ferrus=debug` (or `info`/`warn`) for verbose logs to stderr.
 |---|---|
 | `/plan` | Free-form planning session with the supervisor (no task created) |
 | `/task` | Define a task with the supervisor, then run executor→review loop |
+| `/spec` | Draft, approve, and save a feature specification |
 | `/supervisor` | Open an interactive supervisor session (no initial prompt) |
 | `/executor` | Open an interactive executor session (no initial prompt) |
 | `/review` | Manually spawn supervisor in review mode (escape hatch) |
@@ -80,6 +81,7 @@ Set `RUST_LOG=ferrus=debug` (or `info`/`warn`) for verbose logs to stderr.
 | Tool | From state | Description |
 |---|---|---|
 | `create_task` | Idle | Write task description; moves to Executing |
+| `create_spec` | any | Write approved Markdown spec to the configured spec directory |
 | `wait_for_review` | — | Long-poll until state is Reviewing |
 | `review_pending` | Reviewing | Read task + submission context |
 | `approve` | Reviewing | Accept; moves to Complete |
@@ -113,6 +115,7 @@ Set `RUST_LOG=ferrus=debug` (or `info`/`warn`) for verbose logs to stderr.
 | `ferrus://submission` | Executor submission notes (`SUBMISSION.md`) |
 | `ferrus://question` | Pending human question (`QUESTION.md`) |
 | `ferrus://consult_template` | Consultation request template (`CONSULT_TEMPLATE.md`) |
+| `ferrus://spec_template` | Feature specification template (`SPEC_TEMPLATE.md`) |
 | `ferrus://consult_request` | Pending supervisor consultation request (`CONSULT_REQUEST.md`) |
 | `ferrus://consult_response` | Supervisor consultation response (`CONSULT_RESPONSE.md`) |
 | `ferrus://state` | Current task state as JSON (`STATE.json`) |
@@ -139,6 +142,9 @@ wait_timeout_secs = 60   # max duration of one wait_* tool call; agents should c
 [lease]
 ttl_secs = 90            # lease validity without renewal
 heartbeat_interval_secs = 30  # how often to call /heartbeat
+
+[spec]
+directory = "docs/specs" # where /create_spec writes approved specs
 ```
 
 ## Runtime files (`.ferrus/`)
@@ -153,6 +159,8 @@ heartbeat_interval_secs = 30  # how often to call /heartbeat
 | `QUESTION.md` | Pending human question |
 | `ANSWER.md` | Human answer |
 | `CONSULT_TEMPLATE.md` | Read-only consultation request template |
+| `SPEC_TEMPLATE.md` | Read-only feature specification template |
+| `LAST_SPEC_PATH` | Last path written by `/create_spec` for HQ handoff |
 | `CONSULT_REQUEST.md` | Pending supervisor consultation request |
 | `CONSULT_RESPONSE.md` | Supervisor consultation response |
 | `logs/check_<n>_<ts>.txt` | Full check output |

--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,5 @@ target
 
 # MCP config
 .claude/settings.local.json
-.claude/.mcp.json
 .mcp.json
 .codex/config.toml
-.qwen/settings.json
-.qwen/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ target
 .claude/.mcp.json
 .mcp.json
 .codex/config.toml
+.qwen/settings.json
+.qwen/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ ferrus register [--supervisor <agent>] [--supervisor-model <model>] [--executor 
 |---|---|
 | `/plan` | Free-form planning session with the supervisor (no task created, no state requirement) |
 | `/task` | Define a task with the supervisor, then run the executor→review loop automatically |
+| `/spec` | Draft, approve, and save a feature specification |
 | `/supervisor` | Open an interactive supervisor session (no initial prompt, no state requirement) |
 | `/executor` | Open an interactive executor session (no initial prompt, no state requirement) |
 | `/resume` | Manually resume the executor headlessly; also recovers Consultation by relaunching both consultant and executor |
@@ -85,6 +86,9 @@ wait_timeout_secs = 60   # max duration of one wait_* MCP call; agent should cal
 ttl_secs = 90            # how long a claimed lease is valid without renewal
 heartbeat_interval_secs = 30  # how often agents should call /heartbeat
 
+[spec]
+directory = "docs/specs" # where /create_spec writes approved specs
+
 [hq.supervisor]
 agent = "claude-code"  # agent for supervisor/reviewer role: claude-code | codex
 model = ""             # optional override; empty = agent default
@@ -113,6 +117,7 @@ model = ""             # optional override; empty = agent default
 | Tool | From state | To state | Description |
 |---|---|---|---|
 | `/create_task` | Idle | Executing | Write task description; Executor picks it up |
+| `/create_spec` | any | — | Write approved Markdown spec to the configured spec directory |
 | `/wait_for_review` | Reviewing | — | Long-poll until state is Reviewing, then return submission context |
 | `/review_pending` | Reviewing | — | Read task + context for review |
 | `/approve` | Reviewing | Complete | Accept the submission |
@@ -150,6 +155,7 @@ model = ""             # optional override; empty = agent default
 | `ferrus://question` | Pending human question (`QUESTION.md`) |
 | `ferrus://answer` | Human answer (`ANSWER.md`) |
 | `ferrus://consult_template` | Consultation request template (`CONSULT_TEMPLATE.md`) |
+| `ferrus://spec_template` | Feature specification template (`SPEC_TEMPLATE.md`) |
 | `ferrus://consult_request` | Pending supervisor consultation request (`CONSULT_REQUEST.md`) |
 | `ferrus://consult_response` | Supervisor consultation response (`CONSULT_RESPONSE.md`) |
 | `ferrus://state` | Current task state as JSON (`STATE.json`) |
@@ -204,6 +210,8 @@ Executor verification is TDD-friendly: `/check` can be run as often as needed du
 | `QUESTION.md` | Question written by `/ask_human` |
 | `ANSWER.md` | Answer written by `/answer` |
 | `CONSULT_TEMPLATE.md` | Read-only consultation request template |
+| `SPEC_TEMPLATE.md` | Read-only feature specification template |
+| `LAST_SPEC_PATH` | Last path written by `/create_spec` for HQ handoff |
 | `CONSULT_REQUEST.md` | Question written by `/consult` |
 | `CONSULT_RESPONSE.md` | Answer written by the consultation Supervisor |
 | `logs/check_<attempt>_<ts>.txt` | Full stdout + stderr for each check run |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ ferrus serve [--role supervisor|executor] [--agent-name <name>] [--agent-index <
     # defaults: agent-name=unknown, agent-index=0
 
 ferrus register [--supervisor <agent>] [--supervisor-model <model>] [--executor <agent>] [--executor-model <model>]
-    # write MCP config for claude-code (.mcp.json) or codex (.codex/config.toml)
+    # write MCP config and tool permissions for claude-code, codex, or qwen-code
     # at least one flag required
     # e.g. ferrus register --supervisor claude-code --executor codex
 ```
@@ -90,11 +90,11 @@ heartbeat_interval_secs = 30  # how often agents should call /heartbeat
 directory = "docs/specs" # where /create_spec writes approved specs
 
 [hq.supervisor]
-agent = "claude-code"  # agent for supervisor/reviewer role: claude-code | codex
+agent = "claude-code"  # agent for supervisor/reviewer role: claude-code | codex | qwen-code
 model = ""             # optional override; empty = agent default
 
 [hq.executor]
-agent = "codex"        # agent for executor role: claude-code | codex
+agent = "codex"        # agent for executor role: claude-code | codex | qwen-code
 model = ""             # optional override; empty = agent default
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrus"
-version = "0.2.5-alpha.12"
+version = "0.2.6-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrus"
-version = "0.2.5-alpha.12"
+version = "0.2.6-alpha.1"
 edition = "2024"
 rust-version = "1.95.0"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Run:
 
 ```sh
 ferrus init                                                # scaffold ferrus.toml + .ferrus/
-ferrus register --supervisor claude-code --executor codex  # write agent configs
+ferrus register --supervisor claude-code --executor codex  # write agent configs and tool permissions
 ferrus                                                     # enter HQ
 ```
 
@@ -188,8 +188,9 @@ Writes agent config files so they automatically load `ferrus serve` as a tool se
 
 | Agent | Config written |
 |---|---|
-| `claude-code` | `.mcp.json` |
+| `claude-code` | `.mcp.json` + `.claude/settings.local.json` permissions |
 | `codex` | `.codex/config.toml` |
+| `qwen-code` | `.qwen/settings.json` + `.qwen/settings.local.json` permissions |
 
 ---
 
@@ -217,11 +218,11 @@ heartbeat_interval_secs = 30   # how often agents should call heartbeat
 directory = "docs/specs"       # where /create_spec writes approved specs
 
 [hq.supervisor]
-agent = "claude-code"  # agent for supervisor/reviewer role: claude-code | codex
+agent = "claude-code"  # agent for supervisor/reviewer role: claude-code | codex | qwen-code
 model = ""             # optional override; empty = agent default
 
 [hq.executor]
-agent = "codex"        # agent for executor role: claude-code | codex
+agent = "codex"        # agent for executor role: claude-code | codex | qwen-code
 model = ""             # optional override; empty = agent default
 ```
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Writes agent config files so they automatically load `ferrus serve` as a tool se
 |---|---|
 | `claude-code` | `.mcp.json` + `.claude/settings.local.json` permissions |
 | `codex` | `.codex/config.toml` |
-| `qwen-code` | `.qwen/settings.local.json` |
+| `qwen-code` | `.qwen/settings.json` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Starts the agent coordination server on stdio. Agents load this as an MCP server
 
 ### `ferrus register --supervisor <agent> [--supervisor-model <model>] --executor <agent> [--executor-model <model>]`
 
-Writes agent config files so they automatically load `ferrus serve` as a tool server. Supported agents:
+Writes agent config files so they automatically load `ferrus serve` as a tool server, and adds only the selected agents' local files to `.gitignore`. Supported agents:
 
 | Agent | Config written |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ On Linux and macOS for `x86_64` and `aarch64`/`arm64`, `install.sh` downloads th
 |---|---|
 | `/plan` | Free-form planning session with the supervisor (no task created) |
 | `/task` | Define a task with the supervisor, then run the executor→review loop automatically |
+| `/spec` | Draft, approve, and save a feature specification |
 | `/supervisor` | Open an interactive supervisor session (no initial prompt) |
 | `/executor` | Open an interactive executor session (no initial prompt) |
 | `/resume` | Manually resume the executor headlessly; also recovers Consultation by relaunching both supervisor and executor |
@@ -177,7 +178,7 @@ Starts the agent coordination server on stdio. Agents load this as an MCP server
 
 | `--role` | Tools exposed |
 |---|---|
-| `supervisor` | `create_task`, `wait_for_review`, `review_pending`, `approve`, `reject`, `respond_consult`, `ask_human`, `answer`, `status`, `reset`, `heartbeat` |
+| `supervisor` | `create_task`, `create_spec`, `wait_for_review`, `review_pending`, `approve`, `reject`, `respond_consult`, `ask_human`, `answer`, `status`, `reset`, `heartbeat` |
 | `executor` | `wait_for_task`, `check`, `consult`, `submit`, `wait_for_consult`, `wait_for_answer`, `ask_human`, `answer`, `status`, `reset`, `heartbeat` |
 | *(omitted)* | All tools |
 
@@ -212,6 +213,9 @@ wait_timeout_secs = 60   # max duration of one wait_* tool call before it return
 ttl_secs = 90                  # how long a claimed lease is valid without renewal
 heartbeat_interval_secs = 30   # how often agents should call heartbeat
 
+[spec]
+directory = "docs/specs"       # where /create_spec writes approved specs
+
 [hq.supervisor]
 agent = "claude-code"  # agent for supervisor/reviewer role: claude-code | codex
 model = ""             # optional override; empty = agent default
@@ -236,6 +240,9 @@ Check commands run in the directory where `ferrus serve` was started. Full outpu
 | `SUBMISSION.md` | Executor submission notes |
 | `QUESTION.md` | Pending human question (written by `/ask_human`) |
 | `ANSWER.md` | Human answer |
+| `CONSULT_TEMPLATE.md` | Read-only consultation request template |
+| `SPEC_TEMPLATE.md` | Read-only feature specification template |
+| `LAST_SPEC_PATH` | Last path written by `/create_spec` for HQ handoff |
 | `CONSULT_REQUEST.md` | Pending supervisor consultation request |
 | `CONSULT_RESPONSE.md` | Supervisor consultation response |
 | `logs/` | Full stdout + stderr per check run; PTY session logs per agent |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ferrus
 
-[![Ferrus version](https://img.shields.io/badge/ferrus-0.2.5--alpha.12-orange)](https://crates.io/crates/ferrus)
+[![Ferrus version](https://img.shields.io/badge/ferrus-0.2.6--alpha.1-orange)](https://crates.io/crates/ferrus)
 [![Rust version](https://img.shields.io/badge/rustc-1.95+-964B00)](https://releases.rs/docs/1.95.0/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/RomanEmreis/ferrus/blob/main/LICENSE)
 [![Rust](https://github.com/RomanEmreis/ferrus/actions/workflows/rust.yml/badge.svg)](https://github.com/RomanEmreis/ferrus/actions/workflows/rust.yml)
@@ -190,7 +190,7 @@ Writes agent config files so they automatically load `ferrus serve` as a tool se
 |---|---|
 | `claude-code` | `.mcp.json` + `.claude/settings.local.json` permissions |
 | `codex` | `.codex/config.toml` |
-| `qwen-code` | `.qwen/settings.json` + `.qwen/settings.local.json` permissions |
+| `qwen-code` | `.qwen/settings.local.json` |
 
 ---
 

--- a/src/agents/claude/mod.rs
+++ b/src/agents/claude/mod.rs
@@ -3,7 +3,11 @@
 //! Ferrus uses this module to normalize Claude's CLI conventions so the rest of
 //! the orchestration layer can treat it like any other agent backend.
 
-use super::{AgentRunMode, ExecutorAgent, SupervisorAgent, normalized_model};
+use super::{
+    AgentRunMode, ExecutorAgent, SupervisorAgent, allow_mcp_server_tools_in_json_settings,
+    normalized_model,
+};
+use anyhow::Result;
 use std::process::Command;
 
 /// Stable agent identifier used in Ferrus configuration and error messages.
@@ -90,6 +94,14 @@ fn claude_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
         }
     }
     cmd
+}
+
+pub(crate) async fn allow_mcp_server_tools(server_key: &str) -> Result<()> {
+    allow_mcp_server_tools_in_json_settings(
+        std::path::Path::new(".claude/settings.local.json"),
+        server_key,
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -6,6 +6,7 @@
 use super::{
     AgentRunMode, ExecutorAgent, HeadlessPromptTransport, SupervisorAgent, normalized_model,
 };
+use crate::agent_id::{ROLE_EXECUTOR, ROLE_SUPERVISOR};
 use std::process::Command;
 
 /// Stable agent identifier used in Ferrus configuration and error messages.
@@ -138,6 +139,56 @@ fn codex_headless_prompt_transport() -> HeadlessPromptTransport {
     }
 }
 
+pub(crate) fn apply_tool_approval_overrides(role: &str, entry: &mut toml::Table) {
+    let tools = entry
+        .entry("tools")
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()))
+        .as_table_mut()
+        .expect("tools must be a TOML table");
+
+    for tool in auto_approved_tools(role) {
+        let mut tool_config = toml::Table::new();
+        tool_config.insert(
+            "approval_mode".to_string(),
+            toml::Value::String("approve".to_string()),
+        );
+        tools.insert(tool.to_string(), toml::Value::Table(tool_config));
+    }
+}
+
+fn auto_approved_tools(role: &str) -> &'static [&'static str] {
+    match role {
+        ROLE_EXECUTOR => &[
+            "wait_for_task",
+            "check",
+            "consult",
+            "submit",
+            "wait_for_consult",
+            "wait_for_answer",
+            "ask_human",
+            "answer",
+            "status",
+            "reset",
+            "heartbeat",
+        ],
+        ROLE_SUPERVISOR => &[
+            "create_task",
+            "create_spec",
+            "wait_for_review",
+            "review_pending",
+            "approve",
+            "reject",
+            "respond_consult",
+            "ask_human",
+            "answer",
+            "status",
+            "reset",
+            "heartbeat",
+        ],
+        _ => &[],
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -227,6 +278,27 @@ mod tests {
         );
         assert_eq!(entry.model, None);
     }
+
+    #[test]
+    fn codex_approves_executor_tools_by_role() {
+        let mut entry = toml::Table::new();
+        apply_tool_approval_overrides("executor", &mut entry);
+        let tools = entry.get("tools").and_then(toml::Value::as_table).unwrap();
+        assert!(tools.contains_key("wait_for_task"));
+        assert!(tools.contains_key("submit"));
+        assert!(!tools.contains_key("approve"));
+    }
+
+    #[test]
+    fn codex_approves_supervisor_tools_by_role() {
+        let mut entry = toml::Table::new();
+        apply_tool_approval_overrides("supervisor", &mut entry);
+        let tools = entry.get("tools").and_then(toml::Value::as_table).unwrap();
+        assert!(tools.contains_key("create_task"));
+        assert!(tools.contains_key("create_spec"));
+        assert!(!tools.contains_key("submit"));
+    }
+
     #[cfg(windows)]
     #[test]
     fn codex_headless_command_uses_stdin_prompt_on_windows() {

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -199,7 +199,8 @@ pub(crate) async fn allow_mcp_server_tools_in_json_settings(
 
     let mut root: Value = if path.exists() {
         let content = tokio::fs::read_to_string(path).await?;
-        serde_json::from_str(&content).unwrap_or(serde_json::json!({}))
+        serde_json::from_str(&content)
+            .with_context(|| format!("Failed to parse {}", path.display()))?
     } else {
         serde_json::json!({})
     };

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -8,6 +8,8 @@ pub(crate) mod codex;
 pub(crate) mod qwen;
 
 use anyhow::{Context, Result, bail};
+use serde_json::Value;
+use std::path::Path;
 use std::process::Command;
 use std::sync::Arc;
 
@@ -187,6 +189,71 @@ pub(crate) fn normalized_model(model: Option<&str>) -> Option<String> {
     })
 }
 
+pub(crate) async fn allow_mcp_server_tools_in_json_settings(
+    path: &Path,
+    server_key: &str,
+) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+
+    let mut root: Value = if path.exists() {
+        let content = tokio::fs::read_to_string(path).await?;
+        serde_json::from_str(&content).unwrap_or(serde_json::json!({}))
+    } else {
+        serde_json::json!({})
+    };
+
+    let permission = mcp_server_tools_permission(server_key);
+    let added = add_json_allow_permission(&mut root, &permission, path)?;
+    let content = serde_json::to_string_pretty(&root)?;
+    tokio::fs::write(path, content).await?;
+    if added {
+        println!("Allowed {permission} in {}", path.display());
+    }
+    Ok(())
+}
+
+fn mcp_server_tools_permission(server_key: &str) -> String {
+    format!("mcp__{server_key}__*")
+}
+
+fn add_json_allow_permission(root: &mut Value, permission: &str, path: &Path) -> Result<bool> {
+    let root_obj = root
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("{} root is not a JSON object", path.display()))?;
+
+    let permissions = root_obj
+        .entry("permissions")
+        .or_insert_with(|| serde_json::json!({}));
+    let permissions_obj = permissions
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("{} permissions is not an object", path.display()))?;
+
+    let allow = permissions_obj
+        .entry("allow")
+        .or_insert_with(|| serde_json::json!([]));
+    let allow_array = allow
+        .as_array_mut()
+        .ok_or_else(|| anyhow::anyhow!("{} permissions.allow is not an array", path.display()))?;
+
+    if allow_array
+        .iter()
+        .any(|value| value.as_str() == Some(permission))
+    {
+        return Ok(false);
+    }
+    if allow_array.iter().any(|value| !value.is_string()) {
+        bail!(
+            "{} permissions.allow must contain only strings",
+            path.display()
+        );
+    }
+
+    allow_array.push(Value::String(permission.to_string()));
+    Ok(true)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -236,6 +303,56 @@ mod tests {
         assert_eq!(
             normalized_model(Some("gpt-5.4")),
             Some("gpt-5.4".to_string())
+        );
+    }
+
+    #[test]
+    fn mcp_permission_uses_mcp_server_wildcard() {
+        assert_eq!(
+            mcp_server_tools_permission("ferrus-supervisor-1"),
+            "mcp__ferrus-supervisor-1__*"
+        );
+    }
+
+    #[test]
+    fn add_json_allow_permission_preserves_existing_entries() {
+        let mut root = serde_json::json!({
+            "permissions": {
+                "allow": ["Bash(cargo test)"]
+            }
+        });
+
+        let added = add_json_allow_permission(
+            &mut root,
+            "mcp__ferrus-executor-1__*",
+            Path::new(".claude/settings.local.json"),
+        )
+        .unwrap();
+        assert!(added);
+        assert_eq!(
+            root["permissions"]["allow"],
+            serde_json::json!(["Bash(cargo test)", "mcp__ferrus-executor-1__*"])
+        );
+    }
+
+    #[test]
+    fn add_json_allow_permission_is_idempotent() {
+        let mut root = serde_json::json!({
+            "permissions": {
+                "allow": ["mcp__ferrus-supervisor-1__*"]
+            }
+        });
+
+        let added = add_json_allow_permission(
+            &mut root,
+            "mcp__ferrus-supervisor-1__*",
+            Path::new(".qwen/settings.local.json"),
+        )
+        .unwrap();
+        assert!(!added);
+        assert_eq!(
+            root["permissions"]["allow"],
+            serde_json::json!(["mcp__ferrus-supervisor-1__*"])
         );
     }
 }

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -346,7 +346,7 @@ mod tests {
         let added = add_json_allow_permission(
             &mut root,
             "mcp__ferrus-supervisor-1__*",
-            Path::new(".qwen/settings.local.json"),
+            Path::new(".qwen/settings.json"),
         )
         .unwrap();
         assert!(!added);

--- a/src/agents/qwen/mod.rs
+++ b/src/agents/qwen/mod.rs
@@ -3,7 +3,11 @@
 //! Ferrus uses this module to normalize Qwen's CLI conventions so the rest of
 //! the orchestration layer can treat it like any other agent backend.
 
-use super::{AgentRunMode, ExecutorAgent, SupervisorAgent, normalized_model};
+use super::{
+    AgentRunMode, ExecutorAgent, SupervisorAgent, allow_mcp_server_tools_in_json_settings,
+    normalized_model,
+};
+use anyhow::Result;
 use std::process::Command;
 
 /// Stable agent identifier used in Ferrus configuration and error messages.
@@ -89,6 +93,14 @@ fn qwen_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
         }
     }
     cmd
+}
+
+pub(crate) async fn allow_mcp_server_tools(server_key: &str) -> Result<()> {
+    allow_mcp_server_tools_in_json_settings(
+        std::path::Path::new(".qwen/settings.local.json"),
+        server_key,
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/src/agents/qwen/mod.rs
+++ b/src/agents/qwen/mod.rs
@@ -96,11 +96,8 @@ fn qwen_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
 }
 
 pub(crate) async fn allow_mcp_server_tools(server_key: &str) -> Result<()> {
-    allow_mcp_server_tools_in_json_settings(
-        std::path::Path::new(".qwen/settings.local.json"),
-        server_key,
-    )
-    .await
+    allow_mcp_server_tools_in_json_settings(std::path::Path::new(".qwen/settings.json"), server_key)
+        .await
 }
 
 #[cfg(test)]

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -1,7 +1,10 @@
 use anyhow::{Context, Result};
 use std::path::Path;
 
-use crate::state::{machine::StateData, store};
+use crate::{
+    state::{machine::StateData, store},
+    templates::SPEC_TEMPLATE,
+};
 
 const DEFAULT_FERRUS_TOML: &str = r#"[checks]
 commands = []
@@ -14,6 +17,9 @@ wait_timeout_secs = 60 # max duration of a single wait_* tool call before it ret
 
 [agents]
 path = ".agents" # root directory for agent skill files
+
+[spec]
+directory = "docs/specs" # directory where /create_spec writes approved specs
 
 [lease]
 ttl_secs = 90              # how long a claimed lease is valid without renewal
@@ -65,6 +71,7 @@ Runtime workflow is defined by the initial prompt and Ferrus MCP tools.
 ## Useful Ferrus tools
 
 - `/create_task`
+- `/create_spec`
 - `/wait_for_review`
 - `/review_pending`
 - `/approve`
@@ -75,6 +82,7 @@ Runtime workflow is defined by the initial prompt and Ferrus MCP tools.
 ## Useful Ferrus resources
 
 - `ferrus://task`
+- `ferrus://spec_template`
 - `ferrus://submission`
 - `ferrus://review`
 - `ferrus://consult_request`
@@ -276,6 +284,7 @@ Set `RUST_LOG=ferrus=debug` (or `info`/`warn`) for verbose logs to stderr.
 |---|---|
 | `/plan` | Free-form planning session with the supervisor (no task created) |
 | `/task` | Define a task with the supervisor, then run executor→review loop |
+| `/spec` | Draft, approve, and save a feature specification |
 | `/supervisor` | Open an interactive supervisor session (no initial prompt) |
 | `/executor` | Open an interactive executor session (no initial prompt) |
 | `/review` | Manually spawn supervisor in review mode (escape hatch) |
@@ -295,6 +304,7 @@ Set `RUST_LOG=ferrus=debug` (or `info`/`warn`) for verbose logs to stderr.
 | Tool | From state | Description |
 |---|---|---|
 | `create_task` | Idle | Write task description; moves to Executing |
+| `create_spec` | any | Write approved Markdown spec to the configured spec directory |
 | `wait_for_review` | — | Long-poll until state is Reviewing |
 | `review_pending` | Reviewing | Read task + submission context |
 | `approve` | Reviewing | Accept; moves to Complete |
@@ -329,6 +339,7 @@ Set `RUST_LOG=ferrus=debug` (or `info`/`warn`) for verbose logs to stderr.
 | `ferrus://question` | Pending human question (`QUESTION.md`) |
 | `ferrus://answer` | Human answer (`ANSWER.md`) |
 | `ferrus://consult_template` | Consultation request template (`CONSULT_TEMPLATE.md`) |
+| `ferrus://spec_template` | Feature specification template (`SPEC_TEMPLATE.md`) |
 | `ferrus://consult_request` | Pending supervisor consultation request (`CONSULT_REQUEST.md`) |
 | `ferrus://consult_response` | Supervisor consultation response (`CONSULT_RESPONSE.md`) |
 | `ferrus://state` | Current task state as JSON (`STATE.json`) |
@@ -356,6 +367,9 @@ wait_timeout_secs = 60   # max duration of one wait_* tool call; agents should c
 ttl_secs = 90            # lease validity without renewal
 heartbeat_interval_secs = 30  # how often to call /heartbeat
 
+[spec]
+directory = "docs/specs" # where /create_spec writes approved specs
+
 [hq.supervisor]
 agent = "claude-code"   # agent for supervisor/reviewer role: claude-code | codex
 model = ""              # optional override; empty = agent default
@@ -377,14 +391,17 @@ model = ""              # optional override; empty = agent default
 | `QUESTION.md` | Pending human question |
 | `ANSWER.md` | Human answer |
 | `CONSULT_TEMPLATE.md` | Read-only consultation request template |
+| `SPEC_TEMPLATE.md` | Read-only feature specification template |
 | `CONSULT_REQUEST.md` | Pending supervisor consultation request |
 | `CONSULT_RESPONSE.md` | Supervisor consultation response |
+| `LAST_SPEC_PATH` | Last path written by `/create_spec` for HQ handoff |
 | `logs/check_<n>_<ts>.txt` | Full check output |
 "#;
 
 pub async fn run(agents_path: String) -> Result<()> {
     create_ferrus_toml(&agents_path).await?;
     create_ferrus_dir().await?;
+    create_spec_dir().await?;
     create_skill_files(&agents_path).await?;
     update_gitignore().await?;
     println!("\nferrus initialized. Run `ferrus serve` to start the MCP server.");
@@ -421,6 +438,14 @@ async fn create_ferrus_dir() -> Result<()> {
         println!("Created .ferrus/CONSULT_TEMPLATE.md");
     }
 
+    let spec_template_path = dir.join("SPEC_TEMPLATE.md");
+    if !spec_template_path.exists() {
+        tokio::fs::write(&spec_template_path, SPEC_TEMPLATE)
+            .await
+            .context("Failed to write .ferrus/SPEC_TEMPLATE.md")?;
+        println!("Created .ferrus/SPEC_TEMPLATE.md");
+    }
+
     let state_path = dir.join("STATE.json");
     if !state_path.exists() {
         store::write_state(&StateData::default())
@@ -437,6 +462,7 @@ async fn create_ferrus_dir() -> Result<()> {
         "ANSWER.md",
         "CONSULT_REQUEST.md",
         "CONSULT_RESPONSE.md",
+        "LAST_SPEC_PATH",
     ] {
         let path = dir.join(filename);
         if !path.exists() {
@@ -467,6 +493,18 @@ async fn create_ferrus_dir() -> Result<()> {
         println!("Created .ferrus/agents.json");
     }
 
+    Ok(())
+}
+
+async fn create_spec_dir() -> Result<()> {
+    let path = Path::new("docs/specs");
+    let existed = path.exists();
+    tokio::fs::create_dir_all(path)
+        .await
+        .context("Failed to create docs/specs/ directory")?;
+    if !existed {
+        println!("Created docs/specs/");
+    }
     Ok(())
 }
 

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -26,11 +26,11 @@ ttl_secs = 90              # how long a claimed lease is valid without renewal
 heartbeat_interval_secs = 30 # how often agents should call /heartbeat
 
 [hq.supervisor]
-agent = "claude-code"  # agent to use for supervisor/reviewer role: claude-code | codex
+agent = "claude-code"  # agent to use for supervisor/reviewer role: claude-code | codex | qwen-code
 model = ""             # optional override; empty = agent default
 
 [hq.executor]
-agent = "codex"        # agent to use for executor role: claude-code | codex
+agent = "codex"        # agent to use for executor role: claude-code | codex | qwen-code
 model = ""             # optional override; empty = agent default
 "#;
 
@@ -371,11 +371,11 @@ heartbeat_interval_secs = 30  # how often to call /heartbeat
 directory = "docs/specs" # where /create_spec writes approved specs
 
 [hq.supervisor]
-agent = "claude-code"   # agent for supervisor/reviewer role: claude-code | codex
+agent = "claude-code"   # agent for supervisor/reviewer role: claude-code | codex | qwen-code
 model = ""              # optional override; empty = agent default
 
 [hq.executor]
-agent = "codex"         # agent for executor role: claude-code | codex
+agent = "codex"         # agent for executor role: claude-code | codex | qwen-code
 model = ""              # optional override; empty = agent default
 ```
 
@@ -561,6 +561,7 @@ async fn update_gitignore() -> Result<()> {
         ".claude/.mcp.json",
         ".mcp.json",
         ".codex/config.toml",
+        ".qwen/settings.local.json",
     ];
 
     if path.exists() {

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -555,14 +555,7 @@ async fn create_skill_files(agents_path: &str) -> Result<()> {
 
 async fn update_gitignore() -> Result<()> {
     let path = Path::new(".gitignore");
-    let entries = [
-        ".ferrus/",
-        ".claude/settings.local.json",
-        ".claude/.mcp.json",
-        ".mcp.json",
-        ".codex/config.toml",
-        ".qwen/settings.local.json",
-    ];
+    let entries = [".ferrus/"];
 
     if path.exists() {
         let mut contents = tokio::fs::read_to_string(path)

--- a/src/cli/commands/register.rs
+++ b/src/cli/commands/register.rs
@@ -218,7 +218,7 @@ async fn register_codex(role: &str, agent_name: &str, model: Option<&str>) -> Re
 async fn register_qwen_code(role: &str, agent_name: &str, model: Option<&str>) -> Result<()> {
     let dir = std::path::Path::new(".qwen");
     tokio::fs::create_dir_all(dir).await?;
-    let path = dir.join("settings.local.json");
+    let path = dir.join("settings.json");
 
     let mut root: serde_json::Value = if path.exists() {
         let content = tokio::fs::read_to_string(&path).await?;
@@ -229,13 +229,13 @@ async fn register_qwen_code(role: &str, agent_name: &str, model: Option<&str>) -
 
     let servers = root
         .as_object_mut()
-        .ok_or_else(|| anyhow::anyhow!(".qwen/settings.local.json root is not a JSON object"))?
+        .ok_or_else(|| anyhow::anyhow!(".qwen/settings.json root is not a JSON object"))?
         .entry("mcpServers")
         .or_insert_with(|| serde_json::json!({}));
 
-    let servers_obj = servers.as_object_mut().ok_or_else(|| {
-        anyhow::anyhow!(".qwen/settings.local.json mcpServers is not a JSON object")
-    })?;
+    let servers_obj = servers
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!(".qwen/settings.json mcpServers is not a JSON object"))?;
 
     let index = count_mcp_entries(servers_obj, role, agent_name) + 1;
     let key = format!("ferrus-{role}-{index}");
@@ -254,7 +254,7 @@ async fn register_qwen_code(role: &str, agent_name: &str, model: Option<&str>) -
     }
     servers_obj.insert(key.clone(), server_entry);
     println!(
-        "Registered {key} in .qwen/settings.local.json (agent_id will be \"{}\")",
+        "Registered {key} in .qwen/settings.json (agent_id will be \"{}\")",
         agent_id(role, agent_name, index)
     );
 
@@ -262,7 +262,7 @@ async fn register_qwen_code(role: &str, agent_name: &str, model: Option<&str>) -
     tokio::fs::write(path, content).await?;
 
     crate::agents::qwen::allow_mcp_server_tools(&key).await?;
-    update_gitignore(&[".qwen/settings.local.json"]).await?;
+    update_gitignore(&[".qwen/settings.json"]).await?;
     append_to_qwen_md(role).await?;
     Ok(())
 }

--- a/src/cli/commands/register.rs
+++ b/src/cli/commands/register.rs
@@ -134,6 +134,7 @@ async fn register_claude_code(role: &str, agent_name: &str, model: Option<&str>)
     let content = serde_json::to_string_pretty(&root)?;
     tokio::fs::write(path, content).await?;
 
+    crate::agents::claude::allow_mcp_server_tools(&key).await?;
     append_to_claude_md(role).await?;
     Ok(())
 }
@@ -198,7 +199,7 @@ async fn register_codex(role: &str, agent_name: &str, model: Option<&str>) -> Re
     if let Some(model) = model {
         entry.insert("model".to_string(), toml::Value::String(model));
     }
-    apply_codex_tool_approval_overrides(role, &mut entry);
+    crate::agents::codex::apply_tool_approval_overrides(role, &mut entry);
     mcp_servers.insert(key.clone(), toml::Value::Table(entry));
     println!(
         "Registered {key} in .codex/config.toml (agent_id will be \"{}\")",
@@ -258,58 +259,9 @@ async fn register_qwen_code(role: &str, agent_name: &str, model: Option<&str>) -
     let content = serde_json::to_string_pretty(&root)?;
     tokio::fs::write(path, content).await?;
 
+    crate::agents::qwen::allow_mcp_server_tools(&key).await?;
     append_to_qwen_md(role).await?;
     Ok(())
-}
-
-fn apply_codex_tool_approval_overrides(role: &str, entry: &mut toml::Table) {
-    let tools = entry
-        .entry("tools")
-        .or_insert_with(|| toml::Value::Table(toml::Table::new()))
-        .as_table_mut()
-        .expect("tools must be a TOML table");
-
-    for tool in codex_auto_approved_tools(role) {
-        let mut tool_config = toml::Table::new();
-        tool_config.insert(
-            "approval_mode".to_string(),
-            toml::Value::String("approve".to_string()),
-        );
-        tools.insert(tool.to_string(), toml::Value::Table(tool_config));
-    }
-}
-
-fn codex_auto_approved_tools(role: &str) -> &'static [&'static str] {
-    match role {
-        ROLE_EXECUTOR => &[
-            "wait_for_task",
-            "check",
-            "consult",
-            "submit",
-            "wait_for_consult",
-            "wait_for_answer",
-            "ask_human",
-            "answer",
-            "status",
-            "reset",
-            "heartbeat",
-        ],
-        ROLE_SUPERVISOR => &[
-            "create_task",
-            "create_spec",
-            "wait_for_review",
-            "review_pending",
-            "approve",
-            "reject",
-            "respond_consult",
-            "ask_human",
-            "answer",
-            "status",
-            "reset",
-            "heartbeat",
-        ],
-        _ => &[],
-    }
 }
 
 async fn append_to_agents_md(role: &str) -> Result<()> {

--- a/src/cli/commands/register.rs
+++ b/src/cli/commands/register.rs
@@ -218,7 +218,7 @@ async fn register_codex(role: &str, agent_name: &str, model: Option<&str>) -> Re
 async fn register_qwen_code(role: &str, agent_name: &str, model: Option<&str>) -> Result<()> {
     let dir = std::path::Path::new(".qwen");
     tokio::fs::create_dir_all(dir).await?;
-    let path = dir.join("settings.json");
+    let path = dir.join("settings.local.json");
 
     let mut root: serde_json::Value = if path.exists() {
         let content = tokio::fs::read_to_string(&path).await?;
@@ -229,13 +229,13 @@ async fn register_qwen_code(role: &str, agent_name: &str, model: Option<&str>) -
 
     let servers = root
         .as_object_mut()
-        .ok_or_else(|| anyhow::anyhow!(".qwen/settings.json root is not a JSON object"))?
+        .ok_or_else(|| anyhow::anyhow!(".qwen/settings.local.json root is not a JSON object"))?
         .entry("mcpServers")
         .or_insert_with(|| serde_json::json!({}));
 
-    let servers_obj = servers
-        .as_object_mut()
-        .ok_or_else(|| anyhow::anyhow!(".qwen/settings.json mcpServers is not a JSON object"))?;
+    let servers_obj = servers.as_object_mut().ok_or_else(|| {
+        anyhow::anyhow!(".qwen/settings.local.json mcpServers is not a JSON object")
+    })?;
 
     let index = count_mcp_entries(servers_obj, role, agent_name) + 1;
     let key = format!("ferrus-{role}-{index}");
@@ -254,7 +254,7 @@ async fn register_qwen_code(role: &str, agent_name: &str, model: Option<&str>) -
     }
     servers_obj.insert(key.clone(), server_entry);
     println!(
-        "Registered {key} in .qwen/settings.json (agent_id will be \"{}\")",
+        "Registered {key} in .qwen/settings.local.json (agent_id will be \"{}\")",
         agent_id(role, agent_name, index)
     );
 

--- a/src/cli/commands/register.rs
+++ b/src/cli/commands/register.rs
@@ -135,6 +135,7 @@ async fn register_claude_code(role: &str, agent_name: &str, model: Option<&str>)
     tokio::fs::write(path, content).await?;
 
     crate::agents::claude::allow_mcp_server_tools(&key).await?;
+    update_gitignore(&[".mcp.json", ".claude/settings.local.json"]).await?;
     append_to_claude_md(role).await?;
     Ok(())
 }
@@ -209,6 +210,7 @@ async fn register_codex(role: &str, agent_name: &str, model: Option<&str>) -> Re
     let content = toml::to_string_pretty(&table)?;
     tokio::fs::write(&path, content).await?;
 
+    update_gitignore(&[".codex/config.toml"]).await?;
     append_to_agents_md(role).await?;
     Ok(())
 }
@@ -260,7 +262,41 @@ async fn register_qwen_code(role: &str, agent_name: &str, model: Option<&str>) -
     tokio::fs::write(path, content).await?;
 
     crate::agents::qwen::allow_mcp_server_tools(&key).await?;
+    update_gitignore(&[".qwen/settings.local.json"]).await?;
     append_to_qwen_md(role).await?;
+    Ok(())
+}
+
+async fn update_gitignore(entries: &[&str]) -> Result<()> {
+    let path = std::path::Path::new(".gitignore");
+    let mut contents = if path.exists() {
+        tokio::fs::read_to_string(path).await?
+    } else {
+        String::new()
+    };
+
+    let mut added_entries = Vec::new();
+    for entry in entries {
+        if contents.lines().any(|line| line == *entry) {
+            continue;
+        }
+
+        if !contents.is_empty() && !contents.ends_with('\n') {
+            contents.push('\n');
+        }
+        contents.push_str(entry);
+        contents.push('\n');
+        added_entries.push(*entry);
+    }
+
+    if added_entries.is_empty() {
+        return Ok(());
+    }
+
+    tokio::fs::write(path, contents).await?;
+    for entry in added_entries {
+        println!("Added {entry} to .gitignore");
+    }
     Ok(())
 }
 

--- a/src/cli/commands/register.rs
+++ b/src/cli/commands/register.rs
@@ -296,6 +296,7 @@ fn codex_auto_approved_tools(role: &str) -> &'static [&'static str] {
         ],
         ROLE_SUPERVISOR => &[
             "create_task",
+            "create_spec",
             "wait_for_review",
             "review_pending",
             "approve",

--- a/src/cli/commands/register.rs
+++ b/src/cli/commands/register.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::agent_id::{ROLE_EXECUTOR, ROLE_SUPERVISOR, agent_id};
 use crate::agents::{McpConfigEntry, parse_executor_agent, parse_supervisor_agent};
@@ -95,7 +95,7 @@ async fn register_claude_code(role: &str, agent_name: &str, model: Option<&str>)
 
     let mut root: serde_json::Value = if path.exists() {
         let content = tokio::fs::read_to_string(path).await?;
-        serde_json::from_str(&content).unwrap_or(serde_json::json!({}))
+        serde_json::from_str(&content).context("Failed to parse .mcp.json")?
     } else {
         serde_json::json!({})
     };
@@ -222,7 +222,7 @@ async fn register_qwen_code(role: &str, agent_name: &str, model: Option<&str>) -
 
     let mut root: serde_json::Value = if path.exists() {
         let content = tokio::fs::read_to_string(&path).await?;
-        serde_json::from_str(&content).unwrap_or(serde_json::json!({}))
+        serde_json::from_str(&content).context("Failed to parse .qwen/settings.json")?
     } else {
         serde_json::json!({})
     };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,6 +10,7 @@ pub struct Config {
     pub checks: ChecksConfig,
     pub limits: LimitsConfig,
     pub lease: LeaseConfig,
+    pub spec: SpecConfig,
     pub hq: Option<HqConfig>,
 }
 
@@ -46,6 +47,13 @@ pub struct LeaseConfig {
     pub heartbeat_interval_secs: u64,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct SpecConfig {
+    /// Directory where `/create_spec` writes approved feature specifications.
+    #[serde(default = "default_spec_directory")]
+    pub directory: String,
+}
+
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct HqAgentConfig {
     pub agent: String,
@@ -65,6 +73,8 @@ struct RawConfig {
     limits: LimitsConfig,
     #[serde(default)]
     lease: LeaseConfig,
+    #[serde(default)]
+    spec: SpecConfig,
     #[serde(default)]
     hq: Option<RawHqConfig>,
 }
@@ -109,6 +119,7 @@ impl TryFrom<RawConfig> for Config {
             checks: raw.checks,
             limits: raw.limits,
             lease: raw.lease,
+            spec: raw.spec,
             hq,
         })
     }
@@ -171,6 +182,14 @@ impl Default for LeaseConfig {
     }
 }
 
+impl Default for SpecConfig {
+    fn default() -> Self {
+        Self {
+            directory: default_spec_directory(),
+        }
+    }
+}
+
 const fn default_max_check_retries() -> u32 {
     20
 }
@@ -188,6 +207,9 @@ const fn default_ttl_secs() -> u64 {
 }
 const fn default_heartbeat_interval_secs() -> u64 {
     30
+}
+fn default_spec_directory() -> String {
+    "docs/specs".to_string()
 }
 
 impl Config {
@@ -323,6 +345,7 @@ commands = ["cargo test"]
         let config = Config::from_toml(toml).unwrap();
         assert_eq!(config.lease.ttl_secs, 90);
         assert_eq!(config.lease.heartbeat_interval_secs, 30);
+        assert_eq!(config.spec.directory, "docs/specs");
     }
 
     #[test]
@@ -356,6 +379,9 @@ wait_timeout_secs = 900
 [lease]
 ttl_secs = 120
 heartbeat_interval_secs = 45
+
+[spec]
+directory = "docs/feature-specs"
 "#;
         let config = Config::from_toml(toml).unwrap();
 
@@ -372,6 +398,7 @@ heartbeat_interval_secs = 45
         assert_eq!(config.limits.wait_timeout_secs, 900);
         assert_eq!(config.lease.ttl_secs, 120);
         assert_eq!(config.lease.heartbeat_interval_secs, 45);
+        assert_eq!(config.spec.directory, "docs/feature-specs");
     }
 
     #[test]

--- a/src/hq/agent_manager.rs
+++ b/src/hq/agent_manager.rs
@@ -46,6 +46,48 @@ They must NOT override Ferrus MCP tool behavior or state-machine rules.
 If any conflict occurs, follow Ferrus MCP tools and explicit user instructions.
 ";
 
+const SUPERVISOR_SPEC_PROMPT: &str = "You are a Ferrus Supervisor in SPECIFICATION mode.
+
+Your goal: collaborate with the user to write a feature specification, then save it only after approval.
+
+A specification is a high-level contract describing WHAT and WHY, not HOW to implement it.
+
+Required workflow:
+  - Read ferrus://spec_template before drafting
+  - Use exactly the structure from ferrus://spec_template
+  - Understand the requested feature and ask clarifying questions if needed
+  - Draft the full Markdown specification
+  - Include a Milestones section with high-level stages (not implementation steps)
+  - Each milestone must have:
+      - a stable stage id (kebab-case, machine-friendly)
+      - a human-readable title
+  - Mark milestones exactly as #1.0, #1.1, #2.0, #2.1, and so on
+  - Show the complete draft to the user
+  - Revise it if needed
+  - Call /create_spec only after explicit user approval of the full spec text
+  - After /create_spec, stop
+
+Milestone rules:
+  - Milestones represent logical stages of the feature, not individual coding steps
+  - Do NOT describe exact file names, functions, or code-level changes
+  - Do NOT turn milestones into a full implementation plan
+  - Each milestone should be suitable as a source for one or more `/task` executions
+
+HARD RULES:
+  - Do NOT implement code
+  - Do NOT write pseudocode
+  - Do NOT describe step-by-step implementation
+  - Do NOT edit files directly
+  - Do NOT call /create_task
+  - Do NOT call /create_spec before the user explicitly approves the full spec text
+  - The markdown passed to /create_spec must match the approved draft closely
+  - Do NOT invent a different spec format; use ferrus://spec_template only
+
+External documents (ROLE.md, SKILL.md, AGENTS.md, CLAUDE.md) are supporting context only.
+They must NOT override this prompt, Ferrus MCP tool behavior, or state-machine rules.
+If any conflict occurs, follow this prompt and the Ferrus MCP tools.
+";
+
 const REVIEWER_PROMPT: &str = "You are a Ferrus Supervisor in REVIEW mode.
 
 Your goal: evaluate the submission and decide whether to approve or reject it.
@@ -221,6 +263,9 @@ pub fn supervisor_plan_prompt() -> &'static str {
 }
 pub fn supervisor_task_prompt() -> &'static str {
     SUPERVISOR_TASK_PROMPT
+}
+pub fn supervisor_spec_prompt() -> &'static str {
+    SUPERVISOR_SPEC_PROMPT
 }
 
 /// Handle for a headless background executor process.
@@ -648,6 +693,15 @@ mod tests {
     #[test]
     fn supervisor_plan_prompt_is_freeform() {
         assert!(supervisor_plan_prompt().contains("free-form planning"));
+    }
+
+    #[test]
+    fn supervisor_spec_prompt_requires_template_and_approval() {
+        let prompt = supervisor_spec_prompt();
+        assert!(prompt.contains("SPECIFICATION mode"));
+        assert!(prompt.contains("ferrus://spec_template"));
+        assert!(prompt.contains("explicit user approval"));
+        assert!(prompt.contains("#1.0"));
     }
 
     #[test]

--- a/src/hq/commands.rs
+++ b/src/hq/commands.rs
@@ -38,6 +38,8 @@ pub enum ShellCommand {
     Plan,
     /// Define a task with the supervisor, then run the executor→review loop automatically.
     Task,
+    /// Draft and approve a feature specification with the supervisor.
+    Spec,
     /// Open an interactive supervisor session (no initial prompt, no state requirement).
     Supervisor,
     /// Open an interactive executor session (no initial prompt, no state requirement).
@@ -154,6 +156,13 @@ mod tests {
         assert!(matches!(
             parse_command("/task").unwrap(),
             ShellCommand::Task
+        ));
+    }
+    #[test]
+    fn parse_spec() {
+        assert!(matches!(
+            parse_command("/spec").unwrap(),
+            ShellCommand::Spec
         ));
     }
     #[test]

--- a/src/hq/mod.rs
+++ b/src/hq/mod.rs
@@ -232,7 +232,7 @@ async fn dispatch(line: &str, ctx: &mut HqContext) -> Result<()> {
                 "  /stop              Stop all running agent sessions\n",
                 "  /reset             Reset state to Idle (clears task files)\n",
                 "  /init              Initialize ferrus in the current directory\n",
-                "  /register          Register agent configs (.mcp.json / .codex/config.toml)\n",
+                "  /register          Register agent configs and permissions\n",
                 "  /model <role> <model>\n",
                 "                     Update the configured model override\n",
                 "  /model <role> --clear\n",

--- a/src/hq/mod.rs
+++ b/src/hq/mod.rs
@@ -1009,8 +1009,7 @@ impl HqContext {
         use tokio::process::Command;
 
         self.ensure_hq_config().await?;
-        ensure_spec_template_file().await?;
-        store::clear_last_spec_path().await?;
+        prepare_spec_session_files().await?;
 
         let supervisor = std::sync::Arc::clone(
             self.supervisor
@@ -1197,14 +1196,21 @@ impl HqContext {
     }
 }
 
-async fn ensure_spec_template_file() -> Result<()> {
+async fn prepare_spec_session_files() -> Result<()> {
+    store::read_state().await.context(
+        "Cannot start /spec because Ferrus is not initialized. Run `ferrus init` first.",
+    )?;
+
     let path = std::path::Path::new(".ferrus/SPEC_TEMPLATE.md");
-    if tokio::fs::try_exists(path).await.unwrap_or(false) {
-        return Ok(());
+    if !tokio::fs::try_exists(path).await.unwrap_or(false) {
+        tokio::fs::write(path, crate::templates::SPEC_TEMPLATE)
+            .await
+            .context("Failed to write .ferrus/SPEC_TEMPLATE.md")?;
     }
-    tokio::fs::write(path, crate::templates::SPEC_TEMPLATE)
+
+    store::clear_last_spec_path()
         .await
-        .context("Failed to write .ferrus/SPEC_TEMPLATE.md")
+        .context("Failed to clear .ferrus/LAST_SPEC_PATH")
 }
 
 async fn reconcile_agent_pids() {

--- a/src/hq/mod.rs
+++ b/src/hq/mod.rs
@@ -220,6 +220,7 @@ async fn dispatch(line: &str, ctx: &mut HqContext) -> Result<()> {
                 "ferrus HQ commands:\n",
                 "  /plan              Free-form planning session with the supervisor\n",
                 "  /task              Define a task with the supervisor, then run executor→review loop\n",
+                "  /spec              Draft, approve, and save a feature specification\n",
                 "  /check             Run the Ferrus check gate deterministically from HQ\n",
                 "  /check --force     Run configured checks from HQ without state requirements\n",
                 "  /supervisor        Open an interactive supervisor session\n",
@@ -246,6 +247,7 @@ async fn dispatch(line: &str, ctx: &mut HqContext) -> Result<()> {
         ShellCommand::Stop => ctx.stop().await?,
         ShellCommand::Plan => ctx.plan().await?,
         ShellCommand::Task => ctx.task().await?,
+        ShellCommand::Spec => ctx.spec().await?,
         ShellCommand::Supervisor => ctx.supervisor_interactive().await?,
         ShellCommand::Executor => ctx.executor_interactive().await?,
         ShellCommand::Resume => ctx.resume().await?,
@@ -1002,6 +1004,93 @@ impl HqContext {
         Ok(())
     }
 
+    async fn spec(&mut self) -> Result<()> {
+        use std::process::Stdio;
+        use tokio::process::Command;
+
+        self.ensure_hq_config().await?;
+        ensure_spec_template_file().await?;
+        store::clear_last_spec_path().await?;
+
+        let supervisor = std::sync::Arc::clone(
+            self.supervisor
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("Supervisor agent is not configured"))?,
+        );
+
+        self.display.info(format!(
+            "Spawning supervisor ({}) for specification drafting…",
+            supervisor.name()
+        ));
+        self.display
+            .info("Collaborate with the supervisor to draft and approve the specification.");
+
+        let mut cmd = Command::from(supervisor.spawn(AgentRunMode::Interactive {
+            prompt: Some(agent_manager::supervisor_spec_prompt()),
+        }));
+
+        let ack_rx = self.display.suspend();
+        let _ = ack_rx.await;
+        let mut resume_guard = ResumeGuard::new(self.display.clone());
+        let program = cmd.as_std().get_program().to_string_lossy().into_owned();
+        let mut child = cmd
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .with_context(|| format!("Failed to spawn {program}"))?;
+        let supervisor_id = self.supervisor_agent_id()?;
+        self.mark_agent_running(
+            ROLE_SUPERVISOR,
+            supervisor.name(),
+            &supervisor_id,
+            child.id(),
+        )
+        .await?;
+
+        let mut created_path = None;
+        let mut ticker = tokio::time::interval(std::time::Duration::from_millis(300));
+        loop {
+            tokio::select! {
+                _ = child.wait() => break,
+                _ = ticker.tick() => {
+                    if let Ok(path) = store::read_last_spec_path().await {
+                        let path = path.trim();
+                        if !path.is_empty() {
+                            created_path = Some(path.to_string());
+                            self.display.muted("Spec created — stopping supervisor…");
+                            let _ = child.kill().await;
+                            let _ = child.wait().await;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        resume_guard.resume_now();
+
+        self.mark_agent_suspended(&supervisor_id).await?;
+
+        if created_path.is_none()
+            && let Ok(path) = store::read_last_spec_path().await
+        {
+            let path = path.trim();
+            if !path.is_empty() {
+                created_path = Some(path.to_string());
+            }
+        }
+
+        if let Some(path) = created_path {
+            self.display.info(format!(
+                "Specification ready: {path}\nUse /task to start implementing a selected part."
+            ));
+        } else {
+            self.display
+                .info("No specification created. Re-run /spec when ready.");
+        }
+        Ok(())
+    }
+
     async fn supervisor_interactive(&mut self) -> Result<()> {
         self.ensure_hq_config().await?;
         let agent = std::sync::Arc::clone(
@@ -1106,6 +1195,16 @@ impl HqContext {
             handle.terminate().await;
         }
     }
+}
+
+async fn ensure_spec_template_file() -> Result<()> {
+    let path = std::path::Path::new(".ferrus/SPEC_TEMPLATE.md");
+    if tokio::fs::try_exists(path).await.unwrap_or(false) {
+        return Ok(());
+    }
+    tokio::fs::write(path, crate::templates::SPEC_TEMPLATE)
+        .await
+        .context("Failed to write .ferrus/SPEC_TEMPLATE.md")
 }
 
 async fn reconcile_agent_pids() {

--- a/src/hq/tui.rs
+++ b/src/hq/tui.rs
@@ -26,6 +26,7 @@ const MAX_COMPLETIONS: usize = 8;
 const COMMANDS: &[(&str, &str)] = &[
     ("/plan", "spawn supervisor, plan a task"),
     ("/task", "define a task and run executor then review"),
+    ("/spec", "draft and save an approved feature spec"),
     ("/check", "run the Ferrus check gate from HQ"),
     ("/supervisor", "open an interactive supervisor session"),
     ("/executor", "open an interactive executor session"),
@@ -1755,7 +1756,7 @@ mod tui_tests {
                 .iter()
                 .map(|(cmd, _)| *cmd)
                 .collect::<Vec<_>>(),
-            vec!["/supervisor", "/status", "/stop"]
+            vec!["/spec", "/supervisor", "/status", "/stop"]
         );
         assert!(!app.completion_active);
     }
@@ -1765,6 +1766,7 @@ mod tui_tests {
         let commands: Vec<&str> = COMMANDS.iter().map(|(cmd, _)| *cmd).collect();
 
         assert!(commands.contains(&"/task"));
+        assert!(commands.contains(&"/spec"));
         assert!(commands.contains(&"/check"));
         assert!(commands.contains(&"/model"));
         assert!(commands.contains(&"/resume"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod hq;
 mod platform;
 mod server;
 mod state;
+mod templates;
 mod update_check;
 
 use clap::Parser;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -42,6 +42,9 @@ pub async fn start(role: Option<Role>, agent_name: String, agent_index: u32) -> 
         app.map_tool("create_task", tools::create_task::handler)
             .with_description(tools::create_task::DESCRIPTION)
             .with_input_schema(|_| ToolSchema::from_json_str(tools::create_task::INPUT_SCHEMA));
+        app.map_tool("create_spec", tools::create_spec::handler)
+            .with_description(tools::create_spec::DESCRIPTION)
+            .with_input_schema(|_| ToolSchema::from_json_str(tools::create_spec::INPUT_SCHEMA));
         {
             let id = agent_id.clone();
             app.map_tool("wait_for_review", move || {
@@ -92,6 +95,7 @@ pub async fn start(role: Option<Role>, agent_name: String, agent_index: u32) -> 
     app.add_resource("ferrus://question", "Question");
     app.add_resource("ferrus://answer", "Answer");
     app.add_resource("ferrus://consult_template", "Consultation Template");
+    app.add_resource("ferrus://spec_template", "Specification Template");
     app.add_resource("ferrus://consult_request", "Consult Request");
     app.add_resource("ferrus://consult_response", "Consult Response");
     app.add_resource("ferrus://state", "State");

--- a/src/server/resources.rs
+++ b/src/server/resources.rs
@@ -1,6 +1,6 @@
 use neva::prelude::*;
 
-use crate::state::store;
+use crate::{state::store, templates::SPEC_TEMPLATE};
 
 fn to_err(e: impl std::fmt::Display) -> Error {
     Error::new(
@@ -35,6 +35,12 @@ pub async fn read(file: String) -> Result<ReadResourceResult, Error> {
             tokio::fs::read_to_string(".ferrus/CONSULT_TEMPLATE.md")
                 .await
                 .unwrap_or_default(),
+        ),
+        "spec_template" => (
+            "text/markdown",
+            tokio::fs::read_to_string(".ferrus/SPEC_TEMPLATE.md")
+                .await
+                .unwrap_or_else(|_| SPEC_TEMPLATE.to_string()),
         ),
         "consult_request" => (
             "text/markdown",

--- a/src/server/tools/create_spec.rs
+++ b/src/server/tools/create_spec.rs
@@ -26,6 +26,9 @@ pub async fn handler(markdown: String) -> Result<String, Error> {
 }
 
 async fn run(markdown: String) -> Result<String> {
+    let _state = store::read_state().await?;
+    store::clear_last_spec_path().await?;
+
     if markdown.trim().is_empty() {
         anyhow::bail!("Cannot create spec: markdown content is empty.");
     }

--- a/src/server/tools/create_spec.rs
+++ b/src/server/tools/create_spec.rs
@@ -1,6 +1,8 @@
 use anyhow::{Context, Result};
 use neva::prelude::*;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
+use tokio::io::AsyncWriteExt;
 use tracing::info;
 
 use crate::{config::Config, state::store};
@@ -48,12 +50,9 @@ async fn run(markdown: String) -> Result<String> {
     let slug = slugify(title);
     let date = chrono::Utc::now().format("%Y-%m-%d");
     let base_name = format!("{date}-{slug}");
-    let path = unique_spec_path(&spec_dir, &base_name).await;
 
     let content = ensure_trailing_newline(markdown);
-    tokio::fs::write(&path, content)
-        .await
-        .with_context(|| format!("Failed to write spec {}", path.display()))?;
+    let path = create_unique_spec_file(&spec_dir, &base_name, content.as_bytes()).await?;
 
     let display_path = path.display().to_string();
     store::write_last_spec_path(&display_path).await?;
@@ -94,14 +93,43 @@ fn slugify(title: &str) -> String {
     }
 }
 
-async fn unique_spec_path(dir: &Path, base_name: &str) -> PathBuf {
-    let mut candidate = dir.join(format!("{base_name}.md"));
+async fn create_unique_spec_file(dir: &Path, base_name: &str, content: &[u8]) -> Result<PathBuf> {
+    let mut candidate = spec_path_candidate(dir, base_name, 1);
     let mut suffix = 2;
-    while tokio::fs::try_exists(&candidate).await.unwrap_or(false) {
-        candidate = dir.join(format!("{base_name}-{suffix}.md"));
-        suffix += 1;
+    loop {
+        match tokio::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+            .await
+        {
+            Ok(mut file) => {
+                file.write_all(content)
+                    .await
+                    .with_context(|| format!("Failed to write spec {}", candidate.display()))?;
+                file.flush()
+                    .await
+                    .with_context(|| format!("Failed to flush spec {}", candidate.display()))?;
+                return Ok(candidate);
+            }
+            Err(err) if err.kind() == ErrorKind::AlreadyExists => {
+                candidate = spec_path_candidate(dir, base_name, suffix);
+                suffix += 1;
+            }
+            Err(err) => {
+                return Err(err)
+                    .with_context(|| format!("Failed to create spec {}", candidate.display()));
+            }
+        }
     }
-    candidate
+}
+
+fn spec_path_candidate(dir: &Path, base_name: &str, suffix: u32) -> PathBuf {
+    if suffix == 1 {
+        dir.join(format!("{base_name}.md"))
+    } else {
+        dir.join(format!("{base_name}-{suffix}.md"))
+    }
 }
 
 fn ensure_trailing_newline(mut markdown: String) -> String {
@@ -129,5 +157,18 @@ mod tests {
     #[test]
     fn slugify_falls_back_for_non_ascii_title() {
         assert_eq!(slugify("спека"), "spec");
+    }
+
+    #[test]
+    fn spec_path_candidate_adds_suffix_after_first_candidate() {
+        let dir = Path::new("docs/specs");
+        assert_eq!(
+            spec_path_candidate(dir, "2026-04-26-feature", 1),
+            dir.join("2026-04-26-feature.md")
+        );
+        assert_eq!(
+            spec_path_candidate(dir, "2026-04-26-feature", 2),
+            dir.join("2026-04-26-feature-2.md")
+        );
     }
 }

--- a/src/server/tools/create_spec.rs
+++ b/src/server/tools/create_spec.rs
@@ -1,0 +1,130 @@
+use anyhow::{Context, Result};
+use neva::prelude::*;
+use std::path::{Path, PathBuf};
+use tracing::info;
+
+use crate::{config::Config, state::store};
+
+use super::tool_err;
+
+pub const DESCRIPTION: &str = "Create an approved feature specification. Writes Markdown to the \
+     configured [spec].directory and records the created path for Ferrus HQ. Must only be called \
+     after explicit user approval of the final spec text.";
+
+pub const INPUT_SCHEMA: &str = r#"{
+    "properties": {
+        "markdown": {
+            "type": "string",
+            "description": "Full approved feature specification in Markdown, following ferrus://spec_template"
+        }
+    },
+    "required": ["markdown"]
+}"#;
+
+pub async fn handler(markdown: String) -> Result<String, Error> {
+    run(markdown).await.map_err(tool_err)
+}
+
+async fn run(markdown: String) -> Result<String> {
+    if markdown.trim().is_empty() {
+        anyhow::bail!("Cannot create spec: markdown content is empty.");
+    }
+
+    let config = Config::load().await?;
+    let directory = config.spec.directory.trim();
+    if directory.is_empty() {
+        anyhow::bail!("Cannot create spec: ferrus.toml [spec].directory is empty.");
+    }
+
+    let spec_dir = PathBuf::from(directory);
+    tokio::fs::create_dir_all(&spec_dir)
+        .await
+        .with_context(|| format!("Failed to create spec directory {}", spec_dir.display()))?;
+
+    let title = extract_title(&markdown).unwrap_or("spec");
+    let slug = slugify(title);
+    let date = chrono::Utc::now().format("%Y-%m-%d");
+    let base_name = format!("{date}-{slug}");
+    let path = unique_spec_path(&spec_dir, &base_name).await;
+
+    let content = ensure_trailing_newline(markdown);
+    tokio::fs::write(&path, content)
+        .await
+        .with_context(|| format!("Failed to write spec {}", path.display()))?;
+
+    let display_path = path.display().to_string();
+    store::write_last_spec_path(&display_path).await?;
+
+    info!("Spec created at {}", display_path);
+    Ok(format!("Spec created at {display_path}."))
+}
+
+fn extract_title(markdown: &str) -> Option<&str> {
+    markdown.lines().find_map(|line| {
+        let trimmed = line.trim();
+        trimmed
+            .strip_prefix("# ")
+            .map(str::trim)
+            .filter(|title| !title.is_empty())
+    })
+}
+
+fn slugify(title: &str) -> String {
+    let mut slug = String::new();
+    let mut previous_dash = false;
+
+    for ch in title.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch);
+            previous_dash = false;
+        } else if !previous_dash && !slug.is_empty() {
+            slug.push('-');
+            previous_dash = true;
+        }
+    }
+
+    let slug = slug.trim_matches('-');
+    if slug.is_empty() {
+        "spec".to_string()
+    } else {
+        slug.to_string()
+    }
+}
+
+async fn unique_spec_path(dir: &Path, base_name: &str) -> PathBuf {
+    let mut candidate = dir.join(format!("{base_name}.md"));
+    let mut suffix = 2;
+    while tokio::fs::try_exists(&candidate).await.unwrap_or(false) {
+        candidate = dir.join(format!("{base_name}-{suffix}.md"));
+        suffix += 1;
+    }
+    candidate
+}
+
+fn ensure_trailing_newline(mut markdown: String) -> String {
+    if !markdown.ends_with('\n') {
+        markdown.push('\n');
+    }
+    markdown
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_first_h1_title() {
+        let markdown = "intro\n# Feature Spec\n\n## Goal\n...";
+        assert_eq!(extract_title(markdown), Some("Feature Spec"));
+    }
+
+    #[test]
+    fn slugifies_title_for_filename() {
+        assert_eq!(slugify("Ferrus /spec: v2!"), "ferrus-spec-v2");
+    }
+
+    #[test]
+    fn slugify_falls_back_for_non_ascii_title() {
+        assert_eq!(slugify("спека"), "spec");
+    }
+}

--- a/src/server/tools/mod.rs
+++ b/src/server/tools/mod.rs
@@ -4,6 +4,7 @@ pub mod ask_human;
 pub mod check;
 pub mod check_gate;
 pub mod consult;
+pub mod create_spec;
 pub mod create_task;
 pub mod heartbeat;
 pub mod reject;

--- a/src/state/store.rs
+++ b/src/state/store.rs
@@ -153,6 +153,18 @@ pub async fn clear_consult_response() -> Result<()> {
     write_file("CONSULT_RESPONSE.md", "").await
 }
 
+pub async fn read_last_spec_path() -> Result<String> {
+    read_file("LAST_SPEC_PATH").await
+}
+
+pub async fn write_last_spec_path(content: &str) -> Result<()> {
+    write_file("LAST_SPEC_PATH", content).await
+}
+
+pub async fn clear_last_spec_path() -> Result<()> {
+    write_last_spec_path("").await
+}
+
 pub async fn clear_question() -> Result<()> {
     write_file("QUESTION.md", "").await
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,0 +1,29 @@
+pub const SPEC_TEMPLATE: &str = r#"# <Feature Name> Specification
+
+## Summary
+Briefly describe the feature and the user or system outcome it should create.
+
+## Goals
+- ...
+
+## Non-Goals
+- ...
+
+## Context
+Relevant repository, product, architectural, or workflow context.
+
+## Requirements
+- ...
+
+## Milestones
+- #1.0 ...
+- #1.1 ...
+- #2.0 ...
+- #2.1 ...
+
+## Acceptance Criteria
+- ...
+
+## Risks and Open Questions
+- ...
+"#;


### PR DESCRIPTION
## Summary

  Adds a new /spec workflow for drafting and saving approved feature specifications before implementation, plus registration QoL improvements for agent-specific
  MCP permissions.

## Changes

  - Added HQ /spec command that starts the supervisor in specification mode.
  - Added supervisor spec prompt requiring:
      - ferrus://spec_template usage
      - explicit user approval before saving
      - required Milestones section with subtasks marked 1.0, 1.1, 2.0, etc.
  - Added MCP tool /create_spec, which accepts approved Markdown and writes it to the configured specs directory.
  - Added [spec] directory = "docs/specs" config with default fallback.
  - Added SPEC_TEMPLATE.md creation during ferrus init and exposed it as ferrus://spec_template.
  - Added .ferrus/LAST_SPEC_PATH as the handoff marker so HQ can detect successful spec creation, stop the supervisor, and print the created path.
  - Updated docs, skills, TUI help/autocomplete, and MCP registration for the new spec workflow.

  ## QoL

  - Moved agent-specific registration behavior out of the central register flow and into agent modules where appropriate.
  - Codex tool approval overrides now live in agents/codex.
  - Claude Code and Qwen Code registration now add MCP tool permissions to:
      - .claude/settings.local.json
      - .qwen/settings.local.json
  - ferrus init no longer writes all agent-specific files to .gitignore.
  - ferrus register now adds only the selected agent’s local/generated files to .gitignore.
  - Qwen’s regular .qwen/settings.json is no longer ignored; only .qwen/settings.local.json is treated as local.

## Type
- [ ] Bug fix
- [x] Feature
- [x] Enhancement
- [ ] Performance
- [x] Documentation
- [ ] Refactor
- [ ] Security
- [ ] Breaking change

## Workflow impact (if applicable)
Does this change affect the Supervisor → Executor → Reviewer flow?

- [ ] No impact
- [x] Minor change (does not alter lifecycle semantics)
- [ ] Changes behavior of an existing step
- [ ] Introduces new state/transition

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)
