### PR TITLE
Unify prompt transport API and stream startup prompts to child processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrus"
-version = "0.2.6-alpha.1"
+version = "0.2.6-alpha.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrus"
-version = "0.2.6-alpha.1"
+version = "0.2.6-alpha.2"
 edition = "2024"
 rust-version = "1.95.0"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ferrus
 
-[![Ferrus version](https://img.shields.io/badge/ferrus-0.2.6--alpha.1-orange)](https://crates.io/crates/ferrus)
+[![Ferrus version](https://img.shields.io/badge/ferrus-0.2.6--alpha.2-orange)](https://crates.io/crates/ferrus)
 [![Rust version](https://img.shields.io/badge/rustc-1.95+-964B00)](https://releases.rs/docs/1.95.0/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/RomanEmreis/ferrus/blob/main/LICENSE)
 [![Rust](https://github.com/RomanEmreis/ferrus/actions/workflows/rust.yml/badge.svg)](https://github.com/RomanEmreis/ferrus/actions/workflows/rust.yml)

--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -3,9 +3,7 @@
 //! These wrappers isolate the CLI details needed to launch Codex in the shapes
 //! Ferrus expects for interactive and headless sessions.
 
-use super::{
-    AgentRunMode, ExecutorAgent, HeadlessPromptTransport, SupervisorAgent, normalized_model,
-};
+use super::{AgentRunMode, ExecutorAgent, PromptTransport, SupervisorAgent, normalized_model};
 use crate::agent_id::{ROLE_EXECUTOR, ROLE_SUPERVISOR};
 use std::process::Command;
 
@@ -61,8 +59,8 @@ impl SupervisorAgent for Supervisor {
         self.model.as_deref()
     }
 
-    fn headless_prompt_transport(&self) -> HeadlessPromptTransport {
-        codex_headless_prompt_transport()
+    fn prompt_transport(&self) -> PromptTransport {
+        codex_prompt_transport()
     }
 }
 
@@ -81,8 +79,8 @@ impl ExecutorAgent for Executor {
         self.model.as_deref()
     }
 
-    fn headless_prompt_transport(&self) -> HeadlessPromptTransport {
-        codex_headless_prompt_transport()
+    fn prompt_transport(&self) -> PromptTransport {
+        codex_prompt_transport()
     }
 }
 
@@ -95,7 +93,20 @@ fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
                 cmd.arg("--model").arg(model);
             }
             if let Some(prompt) = prompt {
-                cmd.arg(prompt);
+                #[cfg(windows)]
+                {
+                    // Keep this in sync with `codex_prompt_transport()`.
+                    // When transport is `Stdin`, Codex must receive `-` sentinel.
+                    let _ = prompt;
+                    match codex_prompt_transport() {
+                        PromptTransport::Stdin => cmd.arg("-"),
+                        PromptTransport::Argv => cmd.arg(prompt),
+                    };
+                }
+                #[cfg(not(windows))]
+                {
+                    cmd.arg(prompt);
+                }
             }
         }
         AgentRunMode::Headless { prompt } => {
@@ -107,14 +118,14 @@ fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
             }
             #[cfg(windows)]
             {
-                // Keep this in sync with `codex_headless_prompt_transport()`.
+                // Keep this in sync with `codex_prompt_transport()`.
                 // When transport is `Stdin`, Codex must receive `-` sentinel.
                 let _ = prompt;
-                match codex_headless_prompt_transport() {
-                    HeadlessPromptTransport::Stdin => {
+                match codex_prompt_transport() {
+                    PromptTransport::Stdin => {
                         cmd.arg("-");
                     }
-                    HeadlessPromptTransport::Argv => {
+                    PromptTransport::Argv => {
                         cmd.arg(prompt);
                     }
                 }
@@ -128,14 +139,14 @@ fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
     cmd
 }
 
-fn codex_headless_prompt_transport() -> HeadlessPromptTransport {
+fn codex_prompt_transport() -> PromptTransport {
     #[cfg(windows)]
     {
-        HeadlessPromptTransport::Stdin
+        PromptTransport::Stdin
     }
     #[cfg(not(windows))]
     {
-        HeadlessPromptTransport::Argv
+        PromptTransport::Argv
     }
 }
 
@@ -216,6 +227,32 @@ mod tests {
             agent.spawn(AgentRunMode::Headless { prompt: "run" }),
             EXECUTABLE,
             expected,
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn codex_interactive_prompt_uses_stdin_on_windows() {
+        let agent = Supervisor::new(None);
+        assert_program_and_args(
+            agent.spawn(AgentRunMode::Interactive {
+                prompt: Some("line one\nline two\n\nline three"),
+            }),
+            EXECUTABLE,
+            &["-"],
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn codex_interactive_prompt_uses_argv_off_windows() {
+        let agent = Supervisor::new(None);
+        assert_program_and_args(
+            agent.spawn(AgentRunMode::Interactive {
+                prompt: Some("line one\nline two"),
+            }),
+            EXECUTABLE,
+            &["line one\nline two"],
         );
     }
 
@@ -329,12 +366,12 @@ mod tests {
     #[test]
     fn codex_uses_stdin_prompt_transport_on_windows() {
         assert_eq!(
-            Executor::new(None).headless_prompt_transport(),
-            HeadlessPromptTransport::Stdin
+            Executor::new(None).prompt_transport(),
+            PromptTransport::Stdin
         );
         assert_eq!(
-            Supervisor::new(None).headless_prompt_transport(),
-            HeadlessPromptTransport::Stdin
+            Supervisor::new(None).prompt_transport(),
+            PromptTransport::Stdin
         );
     }
 
@@ -342,12 +379,12 @@ mod tests {
     #[test]
     fn codex_uses_argv_prompt_transport_off_windows() {
         assert_eq!(
-            Executor::new(None).headless_prompt_transport(),
-            HeadlessPromptTransport::Argv
+            Executor::new(None).prompt_transport(),
+            PromptTransport::Argv
         );
         assert_eq!(
-            Supervisor::new(None).headless_prompt_transport(),
-            HeadlessPromptTransport::Argv
+            Supervisor::new(None).prompt_transport(),
+            PromptTransport::Argv
         );
     }
 }

--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -207,12 +207,16 @@ mod tests {
     #[test]
     fn codex_supervisor_builds_interactive_command() {
         let agent = Supervisor::new(None);
+        #[cfg(windows)]
+        let expected: &[&str] = &["-"];
+        #[cfg(not(windows))]
+        let expected: &[&str] = &["plan"];
         assert_program_and_args(
             agent.spawn(AgentRunMode::Interactive {
                 prompt: Some("plan"),
             }),
             EXECUTABLE,
-            &["plan"],
+            expected,
         );
     }
 

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -34,9 +34,9 @@ pub enum AgentRunMode<'a> {
     Headless { prompt: &'a str },
 }
 
-/// Declares how a headless prompt should be transported to the child process.
+/// Declares how a startup prompt should be transported to the child process.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum HeadlessPromptTransport {
+pub enum PromptTransport {
     /// Pass prompt as a regular CLI argument.
     Argv,
     /// Pass prompt via stdin and close stdin after writing.
@@ -75,9 +75,9 @@ pub trait SupervisorAgent: Send + Sync {
     /// Returns the optional model override used by this backend.
     fn model(&self) -> Option<&str>;
 
-    /// Describes how headless prompt text should be delivered.
-    fn headless_prompt_transport(&self) -> HeadlessPromptTransport {
-        HeadlessPromptTransport::Argv
+    /// Describes how startup prompt text should be delivered.
+    fn prompt_transport(&self) -> PromptTransport {
+        PromptTransport::Argv
     }
 }
 
@@ -109,9 +109,9 @@ pub trait ExecutorAgent: Send + Sync {
     /// Returns the optional model override used by this backend.
     fn model(&self) -> Option<&str>;
 
-    /// Describes how headless prompt text should be delivered.
-    fn headless_prompt_transport(&self) -> HeadlessPromptTransport {
-        HeadlessPromptTransport::Argv
+    /// Describes how startup prompt text should be delivered.
+    fn prompt_transport(&self) -> PromptTransport {
+        PromptTransport::Argv
     }
 }
 

--- a/src/hq/agent_manager.rs
+++ b/src/hq/agent_manager.rs
@@ -1,5 +1,5 @@
 use crate::agent_id::{ROLE_EXECUTOR, ROLE_SUPERVISOR};
-use crate::agents::{AgentRunMode, ExecutorAgent, HeadlessPromptTransport, SupervisorAgent};
+use crate::agents::{AgentRunMode, ExecutorAgent, PromptTransport, SupervisorAgent};
 use crate::platform::{self, ShutdownSignal};
 use crate::state::agents::{AgentEntry, AgentStatus, read_agents, write_agents};
 use anyhow::{Context, Result};
@@ -333,7 +333,7 @@ pub async fn spawn_headless_executor(
     spawn_headless(
         agent.name(),
         command,
-        agent.headless_prompt_transport(),
+        agent.prompt_transport(),
         ROLE_EXECUTOR,
         name,
         prompt,
@@ -352,7 +352,7 @@ pub async fn spawn_headless_supervisor(
     spawn_headless(
         agent.name(),
         command,
-        agent.headless_prompt_transport(),
+        agent.prompt_transport(),
         ROLE_SUPERVISOR,
         name,
         prompt,
@@ -364,7 +364,7 @@ pub async fn spawn_headless_supervisor(
 async fn spawn_headless(
     agent_type: &str,
     mut command: StdCommand,
-    prompt_transport: HeadlessPromptTransport,
+    prompt_transport: PromptTransport,
     role: &str,
     name: &str,
     prompt: &str,
@@ -391,7 +391,7 @@ async fn spawn_headless(
         let log_stderr = log_file
             .try_clone()
             .context("Failed to clone log file handle")?;
-        let stdin = if prompt_transport == HeadlessPromptTransport::Stdin {
+        let stdin = if prompt_transport == PromptTransport::Stdin {
             Stdio::piped()
         } else {
             Stdio::null()
@@ -402,7 +402,7 @@ async fn spawn_headless(
             .stderr(Stdio::from(log_stderr));
         None
     } else {
-        let stdin = if prompt_transport == HeadlessPromptTransport::Stdin {
+        let stdin = if prompt_transport == PromptTransport::Stdin {
             Stdio::piped()
         } else {
             Stdio::null()
@@ -424,7 +424,7 @@ async fn spawn_headless(
             log_path.display()
         )
     })?;
-    if prompt_transport == HeadlessPromptTransport::Stdin {
+    if prompt_transport == PromptTransport::Stdin {
         stream_prompt_to_stdin(&mut child, prompt).context("Failed to stream initial prompt")?;
     }
 

--- a/src/hq/mod.rs
+++ b/src/hq/mod.rs
@@ -629,10 +629,11 @@ impl HqContext {
             .stderr(Stdio::inherit())
             .spawn()
             .with_context(|| format!("Failed to spawn {program}"))?;
+        let mut stdin_forwarder = None;
         if let Some(prompt) = prompt
             && prompt_transport == PromptTransport::Stdin
         {
-            stream_prompt_to_stdin(&mut child, prompt)
+            stdin_forwarder = prime_prompt_and_forward_stdin(&mut child, prompt)
                 .await
                 .context("Failed to stream interactive startup prompt")?;
         }
@@ -640,6 +641,9 @@ impl HqContext {
             .await?;
 
         let _ = child.wait().await;
+        if let Some(handle) = stdin_forwarder {
+            handle.abort();
+        }
         guard.resume_now();
         self.mark_agent_suspended(name).await?;
         Ok(())
@@ -987,10 +991,12 @@ impl HqContext {
             .stderr(Stdio::inherit())
             .spawn()
             .with_context(|| format!("Failed to spawn {program}"))?;
+        let mut stdin_forwarder = None;
         if prompt_transport == PromptTransport::Stdin {
-            stream_prompt_to_stdin(&mut child, agent_manager::supervisor_task_prompt())
-                .await
-                .context("Failed to stream interactive startup prompt")?;
+            stdin_forwarder =
+                prime_prompt_and_forward_stdin(&mut child, agent_manager::supervisor_task_prompt())
+                    .await
+                    .context("Failed to stream interactive startup prompt")?;
         }
         let supervisor_id = self.supervisor_agent_id()?;
         self.mark_agent_running(
@@ -1015,6 +1021,9 @@ impl HqContext {
                     }
                 }
             }
+        }
+        if let Some(handle) = stdin_forwarder {
+            handle.abort();
         }
         resume_guard.resume_now();
 
@@ -1071,10 +1080,12 @@ impl HqContext {
             .stderr(Stdio::inherit())
             .spawn()
             .with_context(|| format!("Failed to spawn {program}"))?;
+        let mut stdin_forwarder = None;
         if prompt_transport == PromptTransport::Stdin {
-            stream_prompt_to_stdin(&mut child, agent_manager::supervisor_spec_prompt())
-                .await
-                .context("Failed to stream interactive startup prompt")?;
+            stdin_forwarder =
+                prime_prompt_and_forward_stdin(&mut child, agent_manager::supervisor_spec_prompt())
+                    .await
+                    .context("Failed to stream interactive startup prompt")?;
         }
         let supervisor_id = self.supervisor_agent_id()?;
         self.mark_agent_running(
@@ -1103,6 +1114,9 @@ impl HqContext {
                     }
                 }
             }
+        }
+        if let Some(handle) = stdin_forwarder {
+            handle.abort();
         }
         resume_guard.resume_now();
 
@@ -1308,13 +1322,24 @@ pub(crate) fn transition_action(from: &TaskState, to: &TaskState) -> TransitionA
     }
 }
 
-async fn stream_prompt_to_stdin(child: &mut tokio::process::Child, prompt: &str) -> Result<()> {
-    use tokio::io::AsyncWriteExt;
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(prompt.as_bytes()).await?;
-        stdin.flush().await?;
-    }
-    Ok(())
+async fn prime_prompt_and_forward_stdin(
+    child: &mut tokio::process::Child,
+    prompt: &str,
+) -> Result<Option<tokio::task::JoinHandle<()>>> {
+    use tokio::io::{AsyncWriteExt, stdin};
+
+    let Some(mut child_stdin) = child.stdin.take() else {
+        return Ok(None);
+    };
+
+    child_stdin.write_all(prompt.as_bytes()).await?;
+    child_stdin.flush().await?;
+
+    let handle = tokio::spawn(async move {
+        let mut terminal_stdin = stdin();
+        let _ = tokio::io::copy(&mut terminal_stdin, &mut child_stdin).await;
+    });
+    Ok(Some(handle))
 }
 
 #[cfg(test)]

--- a/src/hq/mod.rs
+++ b/src/hq/mod.rs
@@ -9,7 +9,7 @@ use tokio::process::Command;
 use tokio::sync::watch;
 
 use crate::agent_id::{DEFAULT_AGENT_INDEX, ROLE_EXECUTOR, ROLE_SUPERVISOR, agent_id};
-use crate::agents::{AgentRunMode, ExecutorAgent, SupervisorAgent};
+use crate::agents::{AgentRunMode, ExecutorAgent, PromptTransport, SupervisorAgent};
 use crate::checks::runner;
 use crate::config::{Config, HqConfig, HqRole, update_hq_agent_config};
 use crate::platform;
@@ -606,6 +606,8 @@ impl HqContext {
         agent_type: &str,
         name: &str,
         command: std::process::Command,
+        prompt: Option<&str>,
+        prompt_transport: PromptTransport,
     ) -> Result<()> {
         use std::process::Stdio;
         use tokio::process::Command;
@@ -616,12 +618,24 @@ impl HqContext {
         let mut guard = ResumeGuard::new(self.display.clone());
         let program = cmd.as_std().get_program().to_string_lossy().into_owned();
 
+        let stdin = if prompt.is_some() && prompt_transport == PromptTransport::Stdin {
+            Stdio::piped()
+        } else {
+            Stdio::inherit()
+        };
         let mut child = cmd
-            .stdin(Stdio::inherit())
+            .stdin(stdin)
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .spawn()
             .with_context(|| format!("Failed to spawn {program}"))?;
+        if let Some(prompt) = prompt
+            && prompt_transport == PromptTransport::Stdin
+        {
+            stream_prompt_to_stdin(&mut child, prompt)
+                .await
+                .context("Failed to stream interactive startup prompt")?;
+        }
         self.mark_agent_running(role, agent_type, name, child.id())
             .await?;
 
@@ -878,6 +892,8 @@ impl HqContext {
             agent.name(),
             name,
             agent.spawn(AgentRunMode::Interactive { prompt }),
+            prompt,
+            agent.prompt_transport(),
         )
         .await
     }
@@ -893,6 +909,8 @@ impl HqContext {
             agent.name(),
             name,
             agent.spawn(AgentRunMode::Interactive { prompt }),
+            prompt,
+            agent.prompt_transport(),
         )
         .await
     }
@@ -958,12 +976,22 @@ impl HqContext {
         let _ = ack_rx.await;
         let mut resume_guard = ResumeGuard::new(self.display.clone());
         let program = cmd.as_std().get_program().to_string_lossy().into_owned();
+        let prompt_transport = supervisor.prompt_transport();
         let mut child = cmd
-            .stdin(Stdio::inherit())
+            .stdin(if prompt_transport == PromptTransport::Stdin {
+                Stdio::piped()
+            } else {
+                Stdio::inherit()
+            })
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .spawn()
             .with_context(|| format!("Failed to spawn {program}"))?;
+        if prompt_transport == PromptTransport::Stdin {
+            stream_prompt_to_stdin(&mut child, agent_manager::supervisor_task_prompt())
+                .await
+                .context("Failed to stream interactive startup prompt")?;
+        }
         let supervisor_id = self.supervisor_agent_id()?;
         self.mark_agent_running(
             ROLE_SUPERVISOR,
@@ -1032,12 +1060,22 @@ impl HqContext {
         let _ = ack_rx.await;
         let mut resume_guard = ResumeGuard::new(self.display.clone());
         let program = cmd.as_std().get_program().to_string_lossy().into_owned();
+        let prompt_transport = supervisor.prompt_transport();
         let mut child = cmd
-            .stdin(Stdio::inherit())
+            .stdin(if prompt_transport == PromptTransport::Stdin {
+                Stdio::piped()
+            } else {
+                Stdio::inherit()
+            })
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .spawn()
             .with_context(|| format!("Failed to spawn {program}"))?;
+        if prompt_transport == PromptTransport::Stdin {
+            stream_prompt_to_stdin(&mut child, agent_manager::supervisor_spec_prompt())
+                .await
+                .context("Failed to stream interactive startup prompt")?;
+        }
         let supervisor_id = self.supervisor_agent_id()?;
         self.mark_agent_running(
             ROLE_SUPERVISOR,
@@ -1268,6 +1306,15 @@ pub(crate) fn transition_action(from: &TaskState, to: &TaskState) -> TransitionA
         // Either way, no spawning needed here.
         _ => TransitionAction::NoOp,
     }
+}
+
+async fn stream_prompt_to_stdin(child: &mut tokio::process::Child, prompt: &str) -> Result<()> {
+    use tokio::io::AsyncWriteExt;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(prompt.as_bytes()).await?;
+        stdin.flush().await?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation

- Provide a single, consistent abstraction for how startup prompts are delivered to child agents and ensure correct behavior across platforms. 
- Make Codex and HQ respect whether prompts should be passed via argv or streamed to stdin, and handle Windows `-` sentinel behavior for stdin-based transport.

### Description

- Renamed the enum and trait hook from `HeadlessPromptTransport`/`headless_prompt_transport` to `PromptTransport`/`prompt_transport` and adjusted docs accordingly.
- Updated the Codex agent (`src/agents/codex/mod.rs`) to use `PromptTransport`, to send the `-` sentinel on Windows when the transport is `Stdin`, and to pick the appropriate transport via `codex_prompt_transport()`.
- Updated HQ components (`src/hq/agent_manager.rs` and `src/hq/mod.rs`) to accept and inspect `PromptTransport`, to set child stdin to `piped()` when needed, and to stream the initial startup prompt into the child's stdin via a new async helper `stream_prompt_to_stdin`.
- Adjusted signatures and call sites (`spawn_headless`, `spawn_interactive_command`, and related calls) and updated unit tests to match the new API and platform behavior; added tests that validate interactive prompt transport differences on Windows vs non-Windows.

### Testing

- Ran the unit test suite with `cargo test`, which includes updated and new tests for `codex` prompt transport and HQ spawning behavior, and the tests passed.
- Verified platform-conditional tests for Windows vs non-Windows code paths are present and exercised by the CI test matrix where applicable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef146d66388332ac1da2659ab186d3)