### PR TITLE
Rollback v0.2.6-alpha.2 prompt/launch changes and bump to v0.2.6-alpha.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrus"
-version = "0.2.6-alpha.2"
+version = "0.2.6-alpha.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrus"
-version = "0.2.6-alpha.2"
+version = "0.2.6-alpha.3"
 edition = "2024"
 rust-version = "1.95.0"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ferrus
 
-[![Ferrus version](https://img.shields.io/badge/ferrus-0.2.6--alpha.2-orange)](https://crates.io/crates/ferrus)
+[![Ferrus version](https://img.shields.io/badge/ferrus-0.2.6--alpha.3-orange)](https://crates.io/crates/ferrus)
 [![Rust version](https://img.shields.io/badge/rustc-1.95+-964B00)](https://releases.rs/docs/1.95.0/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/RomanEmreis/ferrus/blob/main/LICENSE)
 [![Rust](https://github.com/RomanEmreis/ferrus/actions/workflows/rust.yml/badge.svg)](https://github.com/RomanEmreis/ferrus/actions/workflows/rust.yml)

--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -91,6 +91,19 @@ fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
     let mut cmd = Command::new(EXECUTABLE);
     match mode {
         AgentRunMode::Interactive { prompt } => {
+            #[cfg(windows)]
+            if let Some(prompt) = prompt {
+                // On Windows, route interactive prompt invocations through `cmd /C`
+                // so `.cmd` shim execution matches terminal behavior.
+                let mut wrapped = Command::new("cmd");
+                wrapped.arg("/D").arg("/S").arg("/C").arg(EXECUTABLE);
+                if let Some(model) = model {
+                    wrapped.arg("--model").arg(model);
+                }
+                wrapped.arg(prompt);
+                return wrapped;
+            }
+
             if let Some(model) = model {
                 cmd.arg("--model").arg(model);
             }
@@ -196,12 +209,22 @@ mod tests {
     #[test]
     fn codex_supervisor_builds_interactive_command() {
         let agent = Supervisor::new(None);
+        #[cfg(windows)]
+        let expected_program = "cmd";
+        #[cfg(not(windows))]
+        let expected_program = EXECUTABLE;
+
+        #[cfg(windows)]
+        let expected_args: &[&str] = &["/D", "/S", "/C", EXECUTABLE, "plan"];
+        #[cfg(not(windows))]
+        let expected_args: &[&str] = &["plan"];
+
         assert_program_and_args(
             agent.spawn(AgentRunMode::Interactive {
                 prompt: Some("plan"),
             }),
-            EXECUTABLE,
-            &["plan"],
+            expected_program,
+            expected_args,
         );
     }
 

--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -3,7 +3,9 @@
 //! These wrappers isolate the CLI details needed to launch Codex in the shapes
 //! Ferrus expects for interactive and headless sessions.
 
-use super::{AgentRunMode, ExecutorAgent, PromptTransport, SupervisorAgent, normalized_model};
+use super::{
+    AgentRunMode, ExecutorAgent, HeadlessPromptTransport, SupervisorAgent, normalized_model,
+};
 use crate::agent_id::{ROLE_EXECUTOR, ROLE_SUPERVISOR};
 use std::process::Command;
 
@@ -59,8 +61,8 @@ impl SupervisorAgent for Supervisor {
         self.model.as_deref()
     }
 
-    fn prompt_transport(&self) -> PromptTransport {
-        codex_prompt_transport()
+    fn headless_prompt_transport(&self) -> HeadlessPromptTransport {
+        codex_headless_prompt_transport()
     }
 }
 
@@ -79,8 +81,8 @@ impl ExecutorAgent for Executor {
         self.model.as_deref()
     }
 
-    fn prompt_transport(&self) -> PromptTransport {
-        codex_prompt_transport()
+    fn headless_prompt_transport(&self) -> HeadlessPromptTransport {
+        codex_headless_prompt_transport()
     }
 }
 
@@ -93,20 +95,7 @@ fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
                 cmd.arg("--model").arg(model);
             }
             if let Some(prompt) = prompt {
-                #[cfg(windows)]
-                {
-                    // Keep this in sync with `codex_prompt_transport()`.
-                    // When transport is `Stdin`, Codex must receive `-` sentinel.
-                    let _ = prompt;
-                    match codex_prompt_transport() {
-                        PromptTransport::Stdin => cmd.arg("-"),
-                        PromptTransport::Argv => cmd.arg(prompt),
-                    };
-                }
-                #[cfg(not(windows))]
-                {
-                    cmd.arg(prompt);
-                }
+                cmd.arg(prompt);
             }
         }
         AgentRunMode::Headless { prompt } => {
@@ -118,14 +107,14 @@ fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
             }
             #[cfg(windows)]
             {
-                // Keep this in sync with `codex_prompt_transport()`.
+                // Keep this in sync with `codex_headless_prompt_transport()`.
                 // When transport is `Stdin`, Codex must receive `-` sentinel.
                 let _ = prompt;
-                match codex_prompt_transport() {
-                    PromptTransport::Stdin => {
+                match codex_headless_prompt_transport() {
+                    HeadlessPromptTransport::Stdin => {
                         cmd.arg("-");
                     }
-                    PromptTransport::Argv => {
+                    HeadlessPromptTransport::Argv => {
                         cmd.arg(prompt);
                     }
                 }
@@ -139,14 +128,14 @@ fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
     cmd
 }
 
-fn codex_prompt_transport() -> PromptTransport {
+fn codex_headless_prompt_transport() -> HeadlessPromptTransport {
     #[cfg(windows)]
     {
-        PromptTransport::Stdin
+        HeadlessPromptTransport::Stdin
     }
     #[cfg(not(windows))]
     {
-        PromptTransport::Argv
+        HeadlessPromptTransport::Argv
     }
 }
 
@@ -207,16 +196,12 @@ mod tests {
     #[test]
     fn codex_supervisor_builds_interactive_command() {
         let agent = Supervisor::new(None);
-        #[cfg(windows)]
-        let expected: &[&str] = &["-"];
-        #[cfg(not(windows))]
-        let expected: &[&str] = &["plan"];
         assert_program_and_args(
             agent.spawn(AgentRunMode::Interactive {
                 prompt: Some("plan"),
             }),
             EXECUTABLE,
-            expected,
+            &["plan"],
         );
     }
 
@@ -231,32 +216,6 @@ mod tests {
             agent.spawn(AgentRunMode::Headless { prompt: "run" }),
             EXECUTABLE,
             expected,
-        );
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn codex_interactive_prompt_uses_stdin_on_windows() {
-        let agent = Supervisor::new(None);
-        assert_program_and_args(
-            agent.spawn(AgentRunMode::Interactive {
-                prompt: Some("line one\nline two\n\nline three"),
-            }),
-            EXECUTABLE,
-            &["-"],
-        );
-    }
-
-    #[cfg(not(windows))]
-    #[test]
-    fn codex_interactive_prompt_uses_argv_off_windows() {
-        let agent = Supervisor::new(None);
-        assert_program_and_args(
-            agent.spawn(AgentRunMode::Interactive {
-                prompt: Some("line one\nline two"),
-            }),
-            EXECUTABLE,
-            &["line one\nline two"],
         );
     }
 
@@ -370,12 +329,12 @@ mod tests {
     #[test]
     fn codex_uses_stdin_prompt_transport_on_windows() {
         assert_eq!(
-            Executor::new(None).prompt_transport(),
-            PromptTransport::Stdin
+            Executor::new(None).headless_prompt_transport(),
+            HeadlessPromptTransport::Stdin
         );
         assert_eq!(
-            Supervisor::new(None).prompt_transport(),
-            PromptTransport::Stdin
+            Supervisor::new(None).headless_prompt_transport(),
+            HeadlessPromptTransport::Stdin
         );
     }
 
@@ -383,12 +342,12 @@ mod tests {
     #[test]
     fn codex_uses_argv_prompt_transport_off_windows() {
         assert_eq!(
-            Executor::new(None).prompt_transport(),
-            PromptTransport::Argv
+            Executor::new(None).headless_prompt_transport(),
+            HeadlessPromptTransport::Argv
         );
         assert_eq!(
-            Supervisor::new(None).prompt_transport(),
-            PromptTransport::Argv
+            Supervisor::new(None).headless_prompt_transport(),
+            HeadlessPromptTransport::Argv
         );
     }
 }

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -34,9 +34,9 @@ pub enum AgentRunMode<'a> {
     Headless { prompt: &'a str },
 }
 
-/// Declares how a startup prompt should be transported to the child process.
+/// Declares how a headless prompt should be transported to the child process.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PromptTransport {
+pub enum HeadlessPromptTransport {
     /// Pass prompt as a regular CLI argument.
     Argv,
     /// Pass prompt via stdin and close stdin after writing.
@@ -75,9 +75,9 @@ pub trait SupervisorAgent: Send + Sync {
     /// Returns the optional model override used by this backend.
     fn model(&self) -> Option<&str>;
 
-    /// Describes how startup prompt text should be delivered.
-    fn prompt_transport(&self) -> PromptTransport {
-        PromptTransport::Argv
+    /// Describes how headless prompt text should be delivered.
+    fn headless_prompt_transport(&self) -> HeadlessPromptTransport {
+        HeadlessPromptTransport::Argv
     }
 }
 
@@ -109,9 +109,9 @@ pub trait ExecutorAgent: Send + Sync {
     /// Returns the optional model override used by this backend.
     fn model(&self) -> Option<&str>;
 
-    /// Describes how startup prompt text should be delivered.
-    fn prompt_transport(&self) -> PromptTransport {
-        PromptTransport::Argv
+    /// Describes how headless prompt text should be delivered.
+    fn headless_prompt_transport(&self) -> HeadlessPromptTransport {
+        HeadlessPromptTransport::Argv
     }
 }
 

--- a/src/hq/agent_manager.rs
+++ b/src/hq/agent_manager.rs
@@ -1,5 +1,5 @@
 use crate::agent_id::{ROLE_EXECUTOR, ROLE_SUPERVISOR};
-use crate::agents::{AgentRunMode, ExecutorAgent, PromptTransport, SupervisorAgent};
+use crate::agents::{AgentRunMode, ExecutorAgent, HeadlessPromptTransport, SupervisorAgent};
 use crate::platform::{self, ShutdownSignal};
 use crate::state::agents::{AgentEntry, AgentStatus, read_agents, write_agents};
 use anyhow::{Context, Result};
@@ -333,7 +333,7 @@ pub async fn spawn_headless_executor(
     spawn_headless(
         agent.name(),
         command,
-        agent.prompt_transport(),
+        agent.headless_prompt_transport(),
         ROLE_EXECUTOR,
         name,
         prompt,
@@ -352,7 +352,7 @@ pub async fn spawn_headless_supervisor(
     spawn_headless(
         agent.name(),
         command,
-        agent.prompt_transport(),
+        agent.headless_prompt_transport(),
         ROLE_SUPERVISOR,
         name,
         prompt,
@@ -364,7 +364,7 @@ pub async fn spawn_headless_supervisor(
 async fn spawn_headless(
     agent_type: &str,
     mut command: StdCommand,
-    prompt_transport: PromptTransport,
+    prompt_transport: HeadlessPromptTransport,
     role: &str,
     name: &str,
     prompt: &str,
@@ -391,7 +391,7 @@ async fn spawn_headless(
         let log_stderr = log_file
             .try_clone()
             .context("Failed to clone log file handle")?;
-        let stdin = if prompt_transport == PromptTransport::Stdin {
+        let stdin = if prompt_transport == HeadlessPromptTransport::Stdin {
             Stdio::piped()
         } else {
             Stdio::null()
@@ -402,7 +402,7 @@ async fn spawn_headless(
             .stderr(Stdio::from(log_stderr));
         None
     } else {
-        let stdin = if prompt_transport == PromptTransport::Stdin {
+        let stdin = if prompt_transport == HeadlessPromptTransport::Stdin {
             Stdio::piped()
         } else {
             Stdio::null()
@@ -424,7 +424,7 @@ async fn spawn_headless(
             log_path.display()
         )
     })?;
-    if prompt_transport == PromptTransport::Stdin {
+    if prompt_transport == HeadlessPromptTransport::Stdin {
         stream_prompt_to_stdin(&mut child, prompt).context("Failed to stream initial prompt")?;
     }
 

--- a/src/hq/mod.rs
+++ b/src/hq/mod.rs
@@ -9,7 +9,7 @@ use tokio::process::Command;
 use tokio::sync::watch;
 
 use crate::agent_id::{DEFAULT_AGENT_INDEX, ROLE_EXECUTOR, ROLE_SUPERVISOR, agent_id};
-use crate::agents::{AgentRunMode, ExecutorAgent, PromptTransport, SupervisorAgent};
+use crate::agents::{AgentRunMode, ExecutorAgent, SupervisorAgent};
 use crate::checks::runner;
 use crate::config::{Config, HqConfig, HqRole, update_hq_agent_config};
 use crate::platform;
@@ -606,8 +606,6 @@ impl HqContext {
         agent_type: &str,
         name: &str,
         command: std::process::Command,
-        prompt: Option<&str>,
-        prompt_transport: PromptTransport,
     ) -> Result<()> {
         use std::process::Stdio;
         use tokio::process::Command;
@@ -618,32 +616,16 @@ impl HqContext {
         let mut guard = ResumeGuard::new(self.display.clone());
         let program = cmd.as_std().get_program().to_string_lossy().into_owned();
 
-        let stdin = if prompt.is_some() && prompt_transport == PromptTransport::Stdin {
-            Stdio::piped()
-        } else {
-            Stdio::inherit()
-        };
         let mut child = cmd
-            .stdin(stdin)
+            .stdin(Stdio::inherit())
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .spawn()
             .with_context(|| format!("Failed to spawn {program}"))?;
-        let mut stdin_forwarder = None;
-        if let Some(prompt) = prompt
-            && prompt_transport == PromptTransport::Stdin
-        {
-            stdin_forwarder = prime_prompt_and_forward_stdin(&mut child, prompt)
-                .await
-                .context("Failed to stream interactive startup prompt")?;
-        }
         self.mark_agent_running(role, agent_type, name, child.id())
             .await?;
 
         let _ = child.wait().await;
-        if let Some(handle) = stdin_forwarder {
-            handle.abort();
-        }
         guard.resume_now();
         self.mark_agent_suspended(name).await?;
         Ok(())
@@ -896,8 +878,6 @@ impl HqContext {
             agent.name(),
             name,
             agent.spawn(AgentRunMode::Interactive { prompt }),
-            prompt,
-            agent.prompt_transport(),
         )
         .await
     }
@@ -913,8 +893,6 @@ impl HqContext {
             agent.name(),
             name,
             agent.spawn(AgentRunMode::Interactive { prompt }),
-            prompt,
-            agent.prompt_transport(),
         )
         .await
     }
@@ -980,24 +958,12 @@ impl HqContext {
         let _ = ack_rx.await;
         let mut resume_guard = ResumeGuard::new(self.display.clone());
         let program = cmd.as_std().get_program().to_string_lossy().into_owned();
-        let prompt_transport = supervisor.prompt_transport();
         let mut child = cmd
-            .stdin(if prompt_transport == PromptTransport::Stdin {
-                Stdio::piped()
-            } else {
-                Stdio::inherit()
-            })
+            .stdin(Stdio::inherit())
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .spawn()
             .with_context(|| format!("Failed to spawn {program}"))?;
-        let mut stdin_forwarder = None;
-        if prompt_transport == PromptTransport::Stdin {
-            stdin_forwarder =
-                prime_prompt_and_forward_stdin(&mut child, agent_manager::supervisor_task_prompt())
-                    .await
-                    .context("Failed to stream interactive startup prompt")?;
-        }
         let supervisor_id = self.supervisor_agent_id()?;
         self.mark_agent_running(
             ROLE_SUPERVISOR,
@@ -1021,9 +987,6 @@ impl HqContext {
                     }
                 }
             }
-        }
-        if let Some(handle) = stdin_forwarder {
-            handle.abort();
         }
         resume_guard.resume_now();
 
@@ -1069,24 +1032,12 @@ impl HqContext {
         let _ = ack_rx.await;
         let mut resume_guard = ResumeGuard::new(self.display.clone());
         let program = cmd.as_std().get_program().to_string_lossy().into_owned();
-        let prompt_transport = supervisor.prompt_transport();
         let mut child = cmd
-            .stdin(if prompt_transport == PromptTransport::Stdin {
-                Stdio::piped()
-            } else {
-                Stdio::inherit()
-            })
+            .stdin(Stdio::inherit())
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .spawn()
             .with_context(|| format!("Failed to spawn {program}"))?;
-        let mut stdin_forwarder = None;
-        if prompt_transport == PromptTransport::Stdin {
-            stdin_forwarder =
-                prime_prompt_and_forward_stdin(&mut child, agent_manager::supervisor_spec_prompt())
-                    .await
-                    .context("Failed to stream interactive startup prompt")?;
-        }
         let supervisor_id = self.supervisor_agent_id()?;
         self.mark_agent_running(
             ROLE_SUPERVISOR,
@@ -1114,9 +1065,6 @@ impl HqContext {
                     }
                 }
             }
-        }
-        if let Some(handle) = stdin_forwarder {
-            handle.abort();
         }
         resume_guard.resume_now();
 
@@ -1320,26 +1268,6 @@ pub(crate) fn transition_action(from: &TaskState, to: &TaskState) -> TransitionA
         // Either way, no spawning needed here.
         _ => TransitionAction::NoOp,
     }
-}
-
-async fn prime_prompt_and_forward_stdin(
-    child: &mut tokio::process::Child,
-    prompt: &str,
-) -> Result<Option<tokio::task::JoinHandle<()>>> {
-    use tokio::io::{AsyncWriteExt, stdin};
-
-    let Some(mut child_stdin) = child.stdin.take() else {
-        return Ok(None);
-    };
-
-    child_stdin.write_all(prompt.as_bytes()).await?;
-    child_stdin.flush().await?;
-
-    let handle = tokio::spawn(async move {
-        let mut terminal_stdin = stdin();
-        let _ = tokio::io::copy(&mut terminal_stdin, &mut child_stdin).await;
-    });
-    Ok(Some(handle))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- Revert the recent changes that altered headless prompt transport and startup behavior introduced in `v0.2.6-alpha.2` to restore the prior, tested behavior from `v0.2.6-alpha.1`.
- Preserve the stable headless spawning API and prompt-delivery semantics used by HQ when launching supervisor/executor processes.
- Bump the crate and documentation to `v0.2.6-alpha.3` to mark the rollback and produce a new release candidate.

### Description
- Restored the headless prompt transport API and semantics by replacing the transient `PromptTransport` usage with `HeadlessPromptTransport` and wiring it through `spawn_headless(...)` and related call sites (changes in `src/agents/mod.rs`, `src/hq/agent_manager.rs`, and `src/agents/codex/mod.rs`).
- Reinstated the previous interactive/headless spawning behavior so HQ streams or passes prompts exactly as before and removed the newer startup prompt-forwarding changes that diverged from `alpha.1` semantics (adjustments in `src/hq/mod.rs` and `src/hq/agent_manager.rs`).
- Bumped package version to `0.2.6-alpha.3` in `Cargo.toml` and `Cargo.lock` and updated the README version badge to `0.2.6-alpha.3`.

### Testing
- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo clippy -- -D warnings` and it failed in this environment due to a toolchain mismatch (`rustc 1.92.0` installed while the project requires `rustc 1.95.0`).
- Ran `cargo test` and it was blocked for the same reason (`rustc 1.92.0` vs required `1.95.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef34706680833295c649df14fbca71)