### PR TITLE
Switch Codex Windows launcher to PowerShell shim and argv prompt transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrus"
-version = "0.2.6-alpha.3"
+version = "0.2.6-alpha.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrus"
-version = "0.2.6-alpha.3"
+version = "0.2.6-alpha.4"
 edition = "2024"
 rust-version = "1.95.0"
 license = "Apache-2.0"

--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -17,6 +17,8 @@ const EXECUTABLE: &str = "codex";
 /// On Windows, use the PowerShell shim.
 #[cfg(windows)]
 const EXECUTABLE: &str = "codex.ps1";
+#[cfg(windows)]
+const POWERSHELL_EXECUTABLE: &str = "powershell";
 
 /// Interactive and headless supervisor launcher for the Codex CLI.
 #[derive(Debug, Clone)]
@@ -88,6 +90,18 @@ impl ExecutorAgent for Executor {
 
 #[inline(always)]
 fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
+    #[cfg(windows)]
+    let mut cmd = {
+        let mut cmd = Command::new(POWERSHELL_EXECUTABLE);
+        cmd.arg("-NoLogo")
+            .arg("-NoProfile")
+            .arg("-ExecutionPolicy")
+            .arg("Bypass")
+            .arg("-File")
+            .arg(EXECUTABLE);
+        cmd
+    };
+    #[cfg(not(windows))]
     let mut cmd = Command::new(EXECUTABLE);
     match mode {
         AgentRunMode::Interactive { prompt } => {
@@ -172,7 +186,21 @@ mod tests {
     #[test]
     fn codex_supervisor_builds_interactive_command() {
         let agent = Supervisor::new(None);
+        #[cfg(windows)]
+        let expected_program = POWERSHELL_EXECUTABLE;
+        #[cfg(not(windows))]
         let expected_program = EXECUTABLE;
+        #[cfg(windows)]
+        let expected_args: &[&str] = &[
+            "-NoLogo",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            EXECUTABLE,
+            "plan",
+        ];
+        #[cfg(not(windows))]
         let expected_args: &[&str] = &["plan"];
 
         assert_program_and_args(
@@ -187,10 +215,26 @@ mod tests {
     #[test]
     fn codex_executor_builds_headless_command() {
         let agent = Executor::new(None);
+        #[cfg(windows)]
+        let expected_program = POWERSHELL_EXECUTABLE;
+        #[cfg(not(windows))]
+        let expected_program = EXECUTABLE;
+        #[cfg(windows)]
+        let expected: &[&str] = &[
+            "-NoLogo",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            EXECUTABLE,
+            "exec",
+            "run",
+        ];
+        #[cfg(not(windows))]
         let expected: &[&str] = &["exec", "run"];
         assert_program_and_args(
             agent.spawn(AgentRunMode::Headless { prompt: "run" }),
-            EXECUTABLE,
+            expected_program,
             expected,
         );
     }
@@ -198,10 +242,28 @@ mod tests {
     #[test]
     fn codex_model_override_is_part_of_spawned_command() {
         let agent = Executor::new(Some("gpt-5.4"));
+        #[cfg(windows)]
+        let expected_program = POWERSHELL_EXECUTABLE;
+        #[cfg(not(windows))]
+        let expected_program = EXECUTABLE;
+        #[cfg(windows)]
+        let expected: &[&str] = &[
+            "-NoLogo",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            EXECUTABLE,
+            "exec",
+            "--model",
+            "gpt-5.4",
+            "run",
+        ];
+        #[cfg(not(windows))]
         let expected: &[&str] = &["exec", "--model", "gpt-5.4", "run"];
         assert_program_and_args(
             agent.spawn(AgentRunMode::Headless { prompt: "run" }),
-            EXECUTABLE,
+            expected_program,
             expected,
         );
     }
@@ -275,12 +337,29 @@ mod tests {
     #[test]
     fn codex_headless_prompt_preserves_newlines() {
         let agent = Executor::new(None);
+        #[cfg(windows)]
+        let expected_program = POWERSHELL_EXECUTABLE;
+        #[cfg(not(windows))]
+        let expected_program = EXECUTABLE;
+        #[cfg(windows)]
+        let expected: &[&str] = &[
+            "-NoLogo",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            EXECUTABLE,
+            "exec",
+            "line one\n\nline two",
+        ];
+        #[cfg(not(windows))]
+        let expected: &[&str] = &["exec", "line one\n\nline two"];
         assert_program_and_args(
             agent.spawn(AgentRunMode::Headless {
                 prompt: "line one\n\nline two",
             }),
-            EXECUTABLE,
-            &["exec", "line one\n\nline two"],
+            expected_program,
+            expected,
         );
     }
 

--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -14,9 +14,9 @@ pub(crate) const NAME: &str = "codex";
 /// Actual CLI executable name used to launch Codex.
 #[cfg(not(windows))]
 const EXECUTABLE: &str = "codex";
-/// On Windows, npm-style shims are commonly installed as `*.cmd`.
+/// On Windows, use the PowerShell shim.
 #[cfg(windows)]
-const EXECUTABLE: &str = "codex.cmd";
+const EXECUTABLE: &str = "codex.ps1";
 
 /// Interactive and headless supervisor launcher for the Codex CLI.
 #[derive(Debug, Clone)]
@@ -91,19 +91,6 @@ fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
     let mut cmd = Command::new(EXECUTABLE);
     match mode {
         AgentRunMode::Interactive { prompt } => {
-            #[cfg(windows)]
-            if let Some(prompt) = prompt {
-                // On Windows, route interactive prompt invocations through `cmd /C`
-                // so `.cmd` shim execution matches terminal behavior.
-                let mut wrapped = Command::new("cmd");
-                wrapped.arg("/D").arg("/S").arg("/C").arg(EXECUTABLE);
-                if let Some(model) = model {
-                    wrapped.arg("--model").arg(model);
-                }
-                wrapped.arg(prompt);
-                return wrapped;
-            }
-
             if let Some(model) = model {
                 cmd.arg("--model").arg(model);
             }
@@ -118,38 +105,14 @@ fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
             if let Some(model) = model {
                 cmd.arg("--model").arg(model);
             }
-            #[cfg(windows)]
-            {
-                // Keep this in sync with `codex_headless_prompt_transport()`.
-                // When transport is `Stdin`, Codex must receive `-` sentinel.
-                let _ = prompt;
-                match codex_headless_prompt_transport() {
-                    HeadlessPromptTransport::Stdin => {
-                        cmd.arg("-");
-                    }
-                    HeadlessPromptTransport::Argv => {
-                        cmd.arg(prompt);
-                    }
-                }
-            }
-            #[cfg(not(windows))]
-            {
-                cmd.arg(prompt);
-            }
+            cmd.arg(prompt);
         }
     }
     cmd
 }
 
 fn codex_headless_prompt_transport() -> HeadlessPromptTransport {
-    #[cfg(windows)]
-    {
-        HeadlessPromptTransport::Stdin
-    }
-    #[cfg(not(windows))]
-    {
-        HeadlessPromptTransport::Argv
-    }
+    HeadlessPromptTransport::Argv
 }
 
 pub(crate) fn apply_tool_approval_overrides(role: &str, entry: &mut toml::Table) {
@@ -209,14 +172,7 @@ mod tests {
     #[test]
     fn codex_supervisor_builds_interactive_command() {
         let agent = Supervisor::new(None);
-        #[cfg(windows)]
-        let expected_program = "cmd";
-        #[cfg(not(windows))]
         let expected_program = EXECUTABLE;
-
-        #[cfg(windows)]
-        let expected_args: &[&str] = &["/D", "/S", "/C", EXECUTABLE, "plan"];
-        #[cfg(not(windows))]
         let expected_args: &[&str] = &["plan"];
 
         assert_program_and_args(
@@ -231,9 +187,6 @@ mod tests {
     #[test]
     fn codex_executor_builds_headless_command() {
         let agent = Executor::new(None);
-        #[cfg(windows)]
-        let expected: &[&str] = &["exec", "-"];
-        #[cfg(not(windows))]
         let expected: &[&str] = &["exec", "run"];
         assert_program_and_args(
             agent.spawn(AgentRunMode::Headless { prompt: "run" }),
@@ -245,9 +198,6 @@ mod tests {
     #[test]
     fn codex_model_override_is_part_of_spawned_command() {
         let agent = Executor::new(Some("gpt-5.4"));
-        #[cfg(windows)]
-        let expected: &[&str] = &["exec", "--model", "gpt-5.4", "-"];
-        #[cfg(not(windows))]
         let expected: &[&str] = &["exec", "--model", "gpt-5.4", "run"];
         assert_program_and_args(
             agent.spawn(AgentRunMode::Headless { prompt: "run" }),
@@ -322,22 +272,8 @@ mod tests {
         assert!(!tools.contains_key("submit"));
     }
 
-    #[cfg(windows)]
     #[test]
-    fn codex_headless_command_uses_stdin_prompt_on_windows() {
-        let agent = Executor::new(None);
-        assert_program_and_args(
-            agent.spawn(AgentRunMode::Headless {
-                prompt: "line one\n\nline two",
-            }),
-            EXECUTABLE,
-            &["exec", "-"],
-        );
-    }
-
-    #[cfg(not(windows))]
-    #[test]
-    fn codex_headless_prompt_preserves_newlines_off_windows() {
+    fn codex_headless_prompt_preserves_newlines() {
         let agent = Executor::new(None);
         assert_program_and_args(
             agent.spawn(AgentRunMode::Headless {
@@ -348,22 +284,8 @@ mod tests {
         );
     }
 
-    #[cfg(windows)]
     #[test]
-    fn codex_uses_stdin_prompt_transport_on_windows() {
-        assert_eq!(
-            Executor::new(None).headless_prompt_transport(),
-            HeadlessPromptTransport::Stdin
-        );
-        assert_eq!(
-            Supervisor::new(None).headless_prompt_transport(),
-            HeadlessPromptTransport::Stdin
-        );
-    }
-
-    #[cfg(not(windows))]
-    #[test]
-    fn codex_uses_argv_prompt_transport_off_windows() {
+    fn codex_uses_argv_prompt_transport() {
         assert_eq!(
             Executor::new(None).headless_prompt_transport(),
             HeadlessPromptTransport::Argv


### PR DESCRIPTION
### Motivation
- Convert Windows Codex invocation to use the PowerShell shim and restore direct argv prompt delivery to simplify cross-platform behavior.
- Unify headless prompt handling so Ferrus can deliver prompts via arguments on Windows as well as other platforms.
- Bump package pre-release to mark the behavior change.

### Description
- Change the Windows Codex executable from `codex.cmd` to `codex.ps1` in `src/agents/codex/mod.rs` and remove the `cmd /C` interactive wrapper so interactive prompts are passed via argv again.
- Switch headless command construction to always pass the prompt via argv (`codex exec <prompt>`) and set `HeadlessPromptTransport` to `Argv` for Codex in `src/agents/codex/mod.rs`.
- Update and simplify unit tests in `src/agents/codex/mod.rs` to expect argv-based prompt behavior on all platforms.
- Bump crate version to `0.2.6-alpha.4` in `Cargo.toml` and update `Cargo.lock`.

### Testing
- Ran `cargo fmt --check`, which completed successfully. 
- Ran `cargo clippy -- -D warnings`, which failed in this environment due to a toolchain mismatch (`rustc 1.92.0` vs crate `rust-version = 1.95.0`).
- Ran `cargo test`, which failed in this environment for the same toolchain mismatch error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef5302473c833299a1adc6509fd89f)