### PR TITLE
Document Windows Codex Node launcher tradeoff and improve error message

### DIFF
--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -186,6 +186,11 @@ fn windows_test_path_override_lock() -> &'static std::sync::Mutex<Option<std::ff
 
 #[cfg(windows)]
 fn windows_codex_invocation() -> Result<(PathBuf, PathBuf)> {
+    // Windows npm shims (`codex.cmd` / `codex.ps1`) are unreliable for Ferrus-managed
+    // interactive/headless sessions, so we resolve the npm-installed Codex JS entrypoint
+    // and launch it through node.exe directly. This intentionally depends on the current
+    // npm package layout and should eventually be replaced by a native Codex binary
+    // launcher when one is consistently available on Windows.
     let shim = resolve_windows_npm_shim_path().ok_or_else(|| {
         anyhow!(
             "Failed to locate codex.cmd or codex.ps1 in PATH; cannot resolve npm base directory \
@@ -206,8 +211,10 @@ fn windows_codex_invocation() -> Result<(PathBuf, PathBuf)> {
         .join("codex.js");
     if !codex_js.is_file() {
         return Err(anyhow!(
-            "Failed to resolve direct Codex launcher script at {}",
-            codex_js.display()
+            "Failed to resolve direct Codex Node launcher. Ferrus currently expects the npm \
+             Codex layout at node_modules/@openai/codex/bin/codex.js on Windows. If this \
+             Codex installation uses a native/Rust binary layout, configure an explicit \
+             Codex executable or reinstall Codex via npm."
         ));
     }
     let local_node = base_dir.join("node.exe");


### PR DESCRIPTION
### Motivation
- Make the Windows Codex resolver behavior explicit and surface a clearer error when the npm-style Codex layout is not found so users know the dependency and how to fix it.

### Description
- Added a comment above `windows_codex_invocation()` explaining why Ferrus bypasses `codex.cmd`/`codex.ps1` and launches the npm `codex.js` through `node.exe`, noting this depends on the npm package layout and should be replaced by a native launcher when available.
- Replaced the previous ambiguous failure text with an explicit message describing the expected path `node_modules/@openai/codex/bin/codex.js` and recommending configuring an explicit executable or reinstalling via npm.
- Modified `src/agents/codex/mod.rs` accordingly.

### Testing
- Ran `cargo fmt --check`, which succeeded.
- Ran `cargo clippy -- -D warnings`, which could not run to completion in this environment due to the installed `rustc` being `1.92.0` while the project requires `1.95.0`.
- Ran `cargo test`, which could not run in this environment for the same `rustc` version mismatch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09ea107c0833288f99bfdd2992823)