### PR TITLE
Centralize MCP server naming and disable opposite-role Codex MCP by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrus"
-version = "0.2.6-alpha.6"
+version = "0.2.6-alpha.7"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrus"
-version = "0.2.6-alpha.6"
+version = "0.2.6-alpha.7"
 edition = "2024"
 rust-version = "1.95.0"
 license = "Apache-2.0"

--- a/src/agent_id.rs
+++ b/src/agent_id.rs
@@ -6,6 +6,10 @@ pub fn agent_id(role: &str, vendor: &str, index: u32) -> String {
     format!("{role}:{vendor}:{index}")
 }
 
+pub fn mcp_server_name(role: &str, index: u32) -> String {
+    format!("ferrus-{role}-{index}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -13,5 +17,10 @@ mod tests {
     #[test]
     fn builds_structured_agent_id() {
         assert_eq!(agent_id("executor", "codex", 1), "executor:codex:1");
+    }
+
+    #[test]
+    fn builds_mcp_server_name() {
+        assert_eq!(mcp_server_name("supervisor", 2), "ferrus-supervisor-2");
     }
 }

--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -6,7 +6,7 @@
 use super::{
     AgentRunMode, ExecutorAgent, HeadlessPromptTransport, SupervisorAgent, normalized_model,
 };
-use crate::agent_id::{ROLE_EXECUTOR, ROLE_SUPERVISOR};
+use crate::agent_id::{DEFAULT_AGENT_INDEX, ROLE_EXECUTOR, ROLE_SUPERVISOR, mcp_server_name};
 use anyhow::Result;
 #[cfg(windows)]
 use anyhow::anyhow;
@@ -60,7 +60,7 @@ impl SupervisorAgent for Supervisor {
 
     /// Builds the Codex command used by Ferrus HQ or an interactive user.
     fn spawn(&self, mode: AgentRunMode<'_>) -> Result<Command> {
-        codex_command(mode, self.model())
+        codex_command(mode, self.model(), ROLE_SUPERVISOR, DEFAULT_AGENT_INDEX)
     }
 
     fn model(&self) -> Option<&str> {
@@ -80,7 +80,7 @@ impl ExecutorAgent for Executor {
 
     /// Builds the Codex command used by Ferrus HQ or an interactive user.
     fn spawn(&self, mode: AgentRunMode<'_>) -> Result<Command> {
-        codex_command(mode, self.model())
+        codex_command(mode, self.model(), ROLE_EXECUTOR, DEFAULT_AGENT_INDEX)
     }
 
     fn model(&self) -> Option<&str> {
@@ -93,7 +93,12 @@ impl ExecutorAgent for Executor {
 }
 
 #[inline(always)]
-fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Result<Command> {
+fn codex_command(
+    mode: AgentRunMode<'_>,
+    model: Option<&str>,
+    role: &str,
+    index: u32,
+) -> Result<Command> {
     #[cfg(windows)]
     let mut cmd = windows_codex_command()?;
     #[cfg(not(windows))]
@@ -123,7 +128,20 @@ fn codex_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Result<Command>
             cmd.arg(prompt);
         }
     }
+    apply_opposite_role_mcp_override(&mut cmd, role, index);
     Ok(cmd)
+}
+
+fn apply_opposite_role_mcp_override(command: &mut Command, role: &str, index: u32) {
+    let opposite_role = match role {
+        ROLE_SUPERVISOR => ROLE_EXECUTOR,
+        ROLE_EXECUTOR => ROLE_SUPERVISOR,
+        _ => return,
+    };
+    let opposite_server = mcp_server_name(opposite_role, index);
+    command
+        .arg("--config")
+        .arg(format!("mcp_servers.{opposite_server}.enabled=false"));
 }
 
 fn codex_headless_prompt_transport() -> HeadlessPromptTransport {
@@ -362,13 +380,19 @@ mod tests {
             program.ends_with(expected_node),
             "expected launcher program ending with {expected_node}, got {program}"
         );
-        assert_eq!(args.len(), 2, "expected codex.js + --version args");
+        assert_eq!(
+            args.len(),
+            4,
+            "expected codex.js + role override + --version args"
+        );
         assert!(
             args[0].ends_with("node_modules\\@openai\\codex\\bin\\codex.js"),
             "expected first arg to be codex.js path, got {}",
             args[0]
         );
-        assert_eq!(args[1], "--version");
+        assert_eq!(args[1], "--config");
+        assert_eq!(args[2], "mcp_servers.ferrus-executor-1.enabled=false");
+        assert_eq!(args[3], "--version");
     }
 
     #[test]
@@ -377,13 +401,21 @@ mod tests {
         #[cfg(not(windows))]
         let expected_program = EXECUTABLE;
         #[cfg(not(windows))]
-        let expected_args: &[&str] = &["plan"];
+        let expected_args: &[&str] = &[
+            "plan",
+            "--config",
+            "mcp_servers.ferrus-executor-1.enabled=false",
+        ];
         #[cfg(windows)]
         assert_windows_program_and_args(
             agent.spawn(AgentRunMode::Interactive {
                 prompt: Some("plan"),
             }),
-            &["plan"],
+            &[
+                "plan",
+                "--config",
+                "mcp_servers.ferrus-executor-1.enabled=false",
+            ],
         );
         #[cfg(not(windows))]
         assert_program_and_args(
@@ -403,11 +435,21 @@ mod tests {
         #[cfg(not(windows))]
         let expected_program = EXECUTABLE;
         #[cfg(not(windows))]
-        let expected: &[&str] = &["exec", "run"];
+        let expected: &[&str] = &[
+            "exec",
+            "run",
+            "--config",
+            "mcp_servers.ferrus-supervisor-1.enabled=false",
+        ];
         #[cfg(windows)]
         assert_windows_program_and_args(
             agent.spawn(AgentRunMode::Headless { prompt: "run" }),
-            &["exec", "-"],
+            &[
+                "exec",
+                "-",
+                "--config",
+                "mcp_servers.ferrus-supervisor-1.enabled=false",
+            ],
         );
         #[cfg(not(windows))]
         assert_program_and_args(
@@ -425,11 +467,25 @@ mod tests {
         #[cfg(not(windows))]
         let expected_program = EXECUTABLE;
         #[cfg(not(windows))]
-        let expected: &[&str] = &["exec", "--model", "gpt-5.4", "run"];
+        let expected: &[&str] = &[
+            "exec",
+            "--model",
+            "gpt-5.4",
+            "run",
+            "--config",
+            "mcp_servers.ferrus-supervisor-1.enabled=false",
+        ];
         #[cfg(windows)]
         assert_windows_program_and_args(
             agent.spawn(AgentRunMode::Headless { prompt: "run" }),
-            &["exec", "--model", "gpt-5.4", "-"],
+            &[
+                "exec",
+                "--model",
+                "gpt-5.4",
+                "-",
+                "--config",
+                "mcp_servers.ferrus-supervisor-1.enabled=false",
+            ],
         );
         #[cfg(not(windows))]
         assert_program_and_args(
@@ -519,7 +575,12 @@ mod tests {
             agent.spawn(AgentRunMode::Headless {
                 prompt: "line one\n\nline two",
             }),
-            &["exec", "-"],
+            &[
+                "exec",
+                "-",
+                "--config",
+                "mcp_servers.ferrus-supervisor-1.enabled=false",
+            ],
         );
         #[cfg(not(windows))]
         assert_program_and_args(
@@ -547,7 +608,15 @@ mod tests {
     fn codex_version_command_uses_expected_shape() {
         let agent = Supervisor::new(None);
         #[cfg(not(windows))]
-        assert_program_and_args(agent.version_command().unwrap(), EXECUTABLE, &["--version"]);
+        assert_program_and_args(
+            agent.version_command().unwrap(),
+            EXECUTABLE,
+            &[
+                "--config",
+                "mcp_servers.ferrus-executor-1.enabled=false",
+                "--version",
+            ],
+        );
 
         #[cfg(windows)]
         {

--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -569,7 +569,12 @@ mod tests {
         #[cfg(not(windows))]
         let expected_program = EXECUTABLE;
         #[cfg(not(windows))]
-        let expected: &[&str] = &["exec", "line one\n\nline two"];
+        let expected: &[&str] = &[
+            "exec",
+            "line one\n\nline two",
+            "--config",
+            "mcp_servers.ferrus-supervisor-1.enabled=false",
+        ];
         #[cfg(windows)]
         assert_windows_program_and_args(
             agent.spawn(AgentRunMode::Headless {

--- a/src/cli/commands/register.rs
+++ b/src/cli/commands/register.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 
-use crate::agent_id::{ROLE_EXECUTOR, ROLE_SUPERVISOR, agent_id};
+use crate::agent_id::{ROLE_EXECUTOR, ROLE_SUPERVISOR, agent_id, mcp_server_name};
 use crate::agents::{McpConfigEntry, parse_executor_agent, parse_supervisor_agent};
 use crate::config::{HqRole, update_hq_agent_config};
 

--- a/src/cli/commands/register.rs
+++ b/src/cli/commands/register.rs
@@ -111,7 +111,7 @@ async fn register_claude_code(role: &str, agent_name: &str, model: Option<&str>)
         .ok_or_else(|| anyhow::anyhow!(".mcp.json mcpServers is not a JSON object"))?;
 
     let index = count_mcp_entries(servers_obj, role, agent_name) + 1;
-    let key = format!("ferrus-{role}-{index}");
+    let key = mcp_server_name(role, index);
     let McpConfigEntry {
         command,
         args,
@@ -180,7 +180,7 @@ async fn register_codex(role: &str, agent_name: &str, model: Option<&str>) -> Re
         .ok_or_else(|| anyhow::anyhow!(".codex/config.toml mcp_servers is not a table"))?;
 
     let index = count_codex_entries(mcp_servers, role, agent_name) + 1;
-    let key = format!("ferrus-{role}-{index}");
+    let key = mcp_server_name(role, index);
     let McpConfigEntry {
         command,
         args,
@@ -238,7 +238,7 @@ async fn register_qwen_code(role: &str, agent_name: &str, model: Option<&str>) -
         .ok_or_else(|| anyhow::anyhow!(".qwen/settings.json mcpServers is not a JSON object"))?;
 
     let index = count_mcp_entries(servers_obj, role, agent_name) + 1;
-    let key = format!("ferrus-{role}-{index}");
+    let key = mcp_server_name(role, index);
     let McpConfigEntry {
         command,
         args,

--- a/src/hq/agent_manager.rs
+++ b/src/hq/agent_manager.rs
@@ -671,7 +671,6 @@ fn parse_mcp_tool_status(line: &str) -> Option<(String, ToolCallStatus)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     #[test]
     fn background_pty_log_path_contains_role() {
         let role = "executor";


### PR DESCRIPTION
### Motivation

- Add a canonical MCP server name helper to avoid duplicated formatting across registrars and agent launching code. 
- Prevent a spawned Codex supervisor or executor from unintentionally enabling the opposite role's MCP server to avoid port/config collisions. 
- Ensure registration and agent spawn commands consistently reference the same MCP server keys.

### Description

- Add `mcp_server_name(role, index)` to `agent_id.rs` and a unit test for it. 
- Update Codex agent launcher to accept `role` and `index` and append a `--config mcp_servers.ferrus-<opposite>-<index>.enabled=false` override via `apply_opposite_role_mcp_override`. 
- Replace inline `format!("ferrus-{role}-{index}")` usages in registrar code for Claude, Codex, and Qwen with `mcp_server_name`. 
- Adjust unit tests in the Codex module and related areas to expect the additional `--config` argument and updated Windows argument counts.

### Testing

- Ran `cargo test` to execute unit tests. 
- Updated and ran `agents::codex` unit tests which now validate the appended `--config` arguments and the new `mcp_server_name` behavior. 
- All automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b3c0ac1c83328c614526751e7846)