### PR TITLE
Add per-role Claude MCP configs and include role-specific `--mcp-config` when launching Claude

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrus"
-version = "0.2.6-alpha.7"
+version = "0.2.6-alpha.8"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrus"
-version = "0.2.6-alpha.7"
+version = "0.2.6-alpha.8"
 edition = "2024"
 rust-version = "1.95.0"
 license = "Apache-2.0"

--- a/src/agents/claude/mod.rs
+++ b/src/agents/claude/mod.rs
@@ -121,6 +121,9 @@ mod tests {
     #[test]
     fn claude_supervisor_builds_interactive_command() {
         let agent = Supervisor::new(None);
+        let role_config = claude_role_mcp_config_path(ROLE_SUPERVISOR)
+            .to_string_lossy()
+            .into_owned();
         assert_program_and_args(
             agent
                 .spawn(AgentRunMode::Interactive {
@@ -128,18 +131,16 @@ mod tests {
                 })
                 .unwrap(),
             "claude",
-            &[
-                "--mcp-config",
-                ".claude/mcp-supervisor.json",
-                "--strict-mcp-config",
-                "plan",
-            ],
+            &["--mcp-config", &role_config, "--strict-mcp-config", "plan"],
         );
     }
 
     #[test]
     fn claude_executor_builds_headless_command() {
         let agent = Executor::new(None);
+        let role_config = claude_role_mcp_config_path(ROLE_EXECUTOR)
+            .to_string_lossy()
+            .into_owned();
         assert_program_and_args(
             agent
                 .spawn(AgentRunMode::Headless { prompt: "run" })
@@ -147,7 +148,7 @@ mod tests {
             "claude",
             &[
                 "--mcp-config",
-                ".claude/mcp-executor.json",
+                &role_config,
                 "--strict-mcp-config",
                 "-p",
                 "run",
@@ -158,6 +159,9 @@ mod tests {
     #[test]
     fn claude_model_override_is_part_of_spawned_command() {
         let agent = Supervisor::new(Some("claude-opus-4-6"));
+        let role_config = claude_role_mcp_config_path(ROLE_SUPERVISOR)
+            .to_string_lossy()
+            .into_owned();
         assert_program_and_args(
             agent
                 .spawn(AgentRunMode::Headless { prompt: "review" })
@@ -165,7 +169,7 @@ mod tests {
             "claude",
             &[
                 "--mcp-config",
-                ".claude/mcp-supervisor.json",
+                &role_config,
                 "--strict-mcp-config",
                 "--model",
                 "claude-opus-4-6",

--- a/src/agents/claude/mod.rs
+++ b/src/agents/claude/mod.rs
@@ -7,7 +7,9 @@ use super::{
     AgentRunMode, ExecutorAgent, SupervisorAgent, allow_mcp_server_tools_in_json_settings,
     normalized_model,
 };
+use crate::agent_id::{ROLE_EXECUTOR, ROLE_SUPERVISOR};
 use anyhow::Result;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Stable agent identifier used in Ferrus configuration and error messages.
@@ -51,7 +53,7 @@ impl SupervisorAgent for Supervisor {
 
     /// Builds the Claude command used by Ferrus HQ or an interactive user.
     fn spawn(&self, mode: AgentRunMode<'_>) -> Result<Command> {
-        Ok(claude_command(mode, self.model()))
+        Ok(claude_command(ROLE_SUPERVISOR, mode, self.model()))
     }
 
     fn model(&self) -> Option<&str> {
@@ -67,7 +69,7 @@ impl ExecutorAgent for Executor {
 
     /// Builds the Claude command used by Ferrus HQ or an interactive user.
     fn spawn(&self, mode: AgentRunMode<'_>) -> Result<Command> {
-        Ok(claude_command(mode, self.model()))
+        Ok(claude_command(ROLE_EXECUTOR, mode, self.model()))
     }
 
     fn model(&self) -> Option<&str> {
@@ -76,8 +78,11 @@ impl ExecutorAgent for Executor {
 }
 
 #[inline(always)]
-fn claude_command(mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
+fn claude_command(role: &str, mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
     let mut cmd = Command::new(EXECUTABLE);
+    cmd.arg("--mcp-config")
+        .arg(claude_role_mcp_config_path(role))
+        .arg("--strict-mcp-config");
     if let Some(model) = model {
         cmd.arg("--model").arg(model);
     }
@@ -104,6 +109,10 @@ pub(crate) async fn allow_mcp_server_tools(server_key: &str) -> Result<()> {
     .await
 }
 
+pub(crate) fn claude_role_mcp_config_path(role: &str) -> PathBuf {
+    Path::new(".claude").join(format!("mcp-{role}.json"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -119,7 +128,12 @@ mod tests {
                 })
                 .unwrap(),
             "claude",
-            &["plan"],
+            &[
+                "--mcp-config",
+                ".claude/mcp-supervisor.json",
+                "--strict-mcp-config",
+                "plan",
+            ],
         );
     }
 
@@ -131,7 +145,13 @@ mod tests {
                 .spawn(AgentRunMode::Headless { prompt: "run" })
                 .unwrap(),
             "claude",
-            &["-p", "run"],
+            &[
+                "--mcp-config",
+                ".claude/mcp-executor.json",
+                "--strict-mcp-config",
+                "-p",
+                "run",
+            ],
         );
     }
 
@@ -143,7 +163,15 @@ mod tests {
                 .spawn(AgentRunMode::Headless { prompt: "review" })
                 .unwrap(),
             "claude",
-            &["--model", "claude-opus-4-6", "-p", "review"],
+            &[
+                "--mcp-config",
+                ".claude/mcp-supervisor.json",
+                "--strict-mcp-config",
+                "--model",
+                "claude-opus-4-6",
+                "-p",
+                "review",
+            ],
         );
     }
 

--- a/src/cli/commands/register.rs
+++ b/src/cli/commands/register.rs
@@ -91,24 +91,27 @@ fn config_entry(
 }
 
 async fn register_claude_code(role: &str, agent_name: &str, model: Option<&str>) -> Result<()> {
-    let path = std::path::Path::new(".mcp.json");
+    let dir = std::path::Path::new(".claude");
+    tokio::fs::create_dir_all(dir).await?;
+    let path = crate::agents::claude::claude_role_mcp_config_path(role);
 
     let mut root: serde_json::Value = if path.exists() {
-        let content = tokio::fs::read_to_string(path).await?;
-        serde_json::from_str(&content).context("Failed to parse .mcp.json")?
+        let content = tokio::fs::read_to_string(&path).await?;
+        serde_json::from_str(&content)
+            .with_context(|| format!("Failed to parse {}", path.display()))?
     } else {
         serde_json::json!({})
     };
 
     let servers = root
         .as_object_mut()
-        .ok_or_else(|| anyhow::anyhow!(".mcp.json root is not a JSON object"))?
+        .ok_or_else(|| anyhow::anyhow!("{} root is not a JSON object", path.display()))?
         .entry("mcpServers")
         .or_insert_with(|| serde_json::json!({}));
 
     let servers_obj = servers
         .as_object_mut()
-        .ok_or_else(|| anyhow::anyhow!(".mcp.json mcpServers is not a JSON object"))?;
+        .ok_or_else(|| anyhow::anyhow!("{} mcpServers is not a JSON object", path.display()))?;
 
     let index = count_mcp_entries(servers_obj, role, agent_name) + 1;
     let key = mcp_server_name(role, index);
@@ -127,15 +130,21 @@ async fn register_claude_code(role: &str, agent_name: &str, model: Option<&str>)
     }
     servers_obj.insert(key.clone(), server_entry);
     println!(
-        "Registered {key} in .mcp.json (agent_id will be \"{}\")",
+        "Registered {key} in {} (agent_id will be \"{}\")",
+        path.display(),
         agent_id(role, agent_name, index)
     );
 
     let content = serde_json::to_string_pretty(&root)?;
-    tokio::fs::write(path, content).await?;
+    tokio::fs::write(&path, content).await?;
 
     crate::agents::claude::allow_mcp_server_tools(&key).await?;
-    update_gitignore(&[".mcp.json", ".claude/settings.local.json"]).await?;
+    update_gitignore(&[
+        ".claude/mcp-supervisor.json",
+        ".claude/mcp-executor.json",
+        ".claude/settings.local.json",
+    ])
+    .await?;
     append_to_claude_md(role).await?;
     Ok(())
 }
@@ -468,6 +477,30 @@ fn normalize_model(model: Option<&str>) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn cwd_test_mutex() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct CurrentDirGuard {
+        previous: std::path::PathBuf,
+    }
+
+    impl CurrentDirGuard {
+        fn change_to(path: &std::path::Path) -> Self {
+            let previous = std::env::current_dir().unwrap();
+            std::env::set_current_dir(path).unwrap();
+            Self { previous }
+        }
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.previous);
+        }
+    }
 
     #[test]
     fn agents_md_supervisor_section_requires_user_approval_before_create_task() {
@@ -527,6 +560,72 @@ mod tests {
         assert_eq!(normalize_model(Some("")), None);
         assert_eq!(normalize_model(Some(" ")), None);
         assert_eq!(normalize_model(Some("gpt-5.4")), Some("gpt-5.4"));
+    }
+
+    #[tokio::test]
+    async fn claude_supervisor_registration_increments_index_in_same_role_file() {
+        let _lock = cwd_test_mutex().lock().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let _cwd_guard = CurrentDirGuard::change_to(temp.path());
+
+        register_claude_code(ROLE_SUPERVISOR, crate::agents::claude::NAME, None)
+            .await
+            .unwrap();
+        register_claude_code(ROLE_SUPERVISOR, crate::agents::claude::NAME, None)
+            .await
+            .unwrap();
+
+        let content = tokio::fs::read_to_string(".claude/mcp-supervisor.json")
+            .await
+            .unwrap();
+        let root: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let servers = root
+            .get("mcpServers")
+            .and_then(serde_json::Value::as_object)
+            .unwrap();
+        assert!(servers.contains_key("ferrus-supervisor-1"));
+        assert!(servers.contains_key("ferrus-supervisor-2"));
+        assert!(!servers.contains_key("ferrus-executor-1"));
+    }
+
+    #[tokio::test]
+    async fn claude_executor_registration_is_role_scoped_and_does_not_change_supervisor_index() {
+        let _lock = cwd_test_mutex().lock().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let _cwd_guard = CurrentDirGuard::change_to(temp.path());
+
+        register_claude_code(ROLE_SUPERVISOR, crate::agents::claude::NAME, None)
+            .await
+            .unwrap();
+        register_claude_code(ROLE_EXECUTOR, crate::agents::claude::NAME, None)
+            .await
+            .unwrap();
+        register_claude_code(ROLE_SUPERVISOR, crate::agents::claude::NAME, None)
+            .await
+            .unwrap();
+
+        let supervisor_content = tokio::fs::read_to_string(".claude/mcp-supervisor.json")
+            .await
+            .unwrap();
+        let supervisor_root: serde_json::Value = serde_json::from_str(&supervisor_content).unwrap();
+        let supervisor_servers = supervisor_root
+            .get("mcpServers")
+            .and_then(serde_json::Value::as_object)
+            .unwrap();
+        assert!(supervisor_servers.contains_key("ferrus-supervisor-1"));
+        assert!(supervisor_servers.contains_key("ferrus-supervisor-2"));
+        assert!(!supervisor_servers.contains_key("ferrus-executor-1"));
+
+        let executor_content = tokio::fs::read_to_string(".claude/mcp-executor.json")
+            .await
+            .unwrap();
+        let executor_root: serde_json::Value = serde_json::from_str(&executor_content).unwrap();
+        let executor_servers = executor_root
+            .get("mcpServers")
+            .and_then(serde_json::Value::as_object)
+            .unwrap();
+        assert!(executor_servers.contains_key("ferrus-executor-1"));
+        assert!(!executor_servers.contains_key("ferrus-supervisor-1"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Scope Claude MCP server registrations to role-specific files under `.claude` so supervisor and executor registrations do not collide.
- Ensure Ferrus launches Claude with the correct MCP configuration for the agent role so the agent receives its role-scoped tools.
- Bump crate version to `0.2.6-alpha.8` to publish these changes.

### Description
- Updated `src/agents/claude/mod.rs` to accept a `role: &str` parameter for `claude_command`, add `--mcp-config <path>` and `--strict-mcp-config` flags when invoking the `claude` executable, and introduced `claude_role_mcp_config_path` which returns `.claude/mcp-<role>.json`.
- Modified `src/cli/commands/register.rs` so `register_claude_code` creates the `.claude` directory, reads and writes role-scoped MCP server files via `claude_role_mcp_config_path`, improves error messages to reference the actual path, and updates `.gitignore` entries to include `.claude/mcp-*.json` and `.claude/settings.local.json`.
- Added and updated unit tests to assert the new CLI args for Claude and to verify role-scoped registration behavior, and introduced a small test helper (`CurrentDirGuard` and a `Mutex`) to safely run filesystem-based tests.
- Bumped package version in `Cargo.toml` and updated `Cargo.lock` to `0.2.6-alpha.8`.

### Testing
- Ran unit tests for the modified modules including `src/agents/claude` and `src/cli/commands/register` which cover CLI argument construction and role-scoped registration behavior; all tests passed.
- Exercised the new async registration tests `claude_supervisor_registration_increments_index_in_same_role_file` and `claude_executor_registration_is_role_scoped_and_does_not_change_supervisor_index` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f21b3b448332b819106692c816ee)