### PR TITLE
Add Claude MCP isolation config and propagate to claude command invocation

### DIFF
--- a/src/agents/claude/mod.rs
+++ b/src/agents/claude/mod.rs
@@ -8,6 +8,7 @@ use super::{
     normalized_model,
 };
 use crate::agent_id::{ROLE_EXECUTOR, ROLE_SUPERVISOR};
+use crate::config::ClaudeMcpIsolation;
 use anyhow::Result;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -21,26 +22,30 @@ const EXECUTABLE: &str = "claude";
 #[derive(Debug, Clone)]
 pub struct Supervisor {
     model: Option<String>,
+    mcp_isolation: ClaudeMcpIsolation,
 }
 
 /// Interactive and headless executor launcher for Claude Code.
 #[derive(Debug, Clone)]
 pub struct Executor {
     model: Option<String>,
+    mcp_isolation: ClaudeMcpIsolation,
 }
 
 impl Supervisor {
-    pub fn new(model: Option<&str>) -> Self {
+    pub fn new(model: Option<&str>, mcp_isolation: ClaudeMcpIsolation) -> Self {
         Self {
             model: normalized_model(model),
+            mcp_isolation,
         }
     }
 }
 
 impl Executor {
-    pub fn new(model: Option<&str>) -> Self {
+    pub fn new(model: Option<&str>, mcp_isolation: ClaudeMcpIsolation) -> Self {
         Self {
             model: normalized_model(model),
+            mcp_isolation,
         }
     }
 }
@@ -53,7 +58,12 @@ impl SupervisorAgent for Supervisor {
 
     /// Builds the Claude command used by Ferrus HQ or an interactive user.
     fn spawn(&self, mode: AgentRunMode<'_>) -> Result<Command> {
-        Ok(claude_command(ROLE_SUPERVISOR, mode, self.model()))
+        Ok(claude_command(
+            ROLE_SUPERVISOR,
+            mode,
+            self.model(),
+            self.mcp_isolation,
+        ))
     }
 
     fn model(&self) -> Option<&str> {
@@ -69,7 +79,12 @@ impl ExecutorAgent for Executor {
 
     /// Builds the Claude command used by Ferrus HQ or an interactive user.
     fn spawn(&self, mode: AgentRunMode<'_>) -> Result<Command> {
-        Ok(claude_command(ROLE_EXECUTOR, mode, self.model()))
+        Ok(claude_command(
+            ROLE_EXECUTOR,
+            mode,
+            self.model(),
+            self.mcp_isolation,
+        ))
     }
 
     fn model(&self) -> Option<&str> {
@@ -78,11 +93,18 @@ impl ExecutorAgent for Executor {
 }
 
 #[inline(always)]
-fn claude_command(role: &str, mode: AgentRunMode<'_>, model: Option<&str>) -> Command {
+fn claude_command(
+    role: &str,
+    mode: AgentRunMode<'_>,
+    model: Option<&str>,
+    isolation: ClaudeMcpIsolation,
+) -> Command {
     let mut cmd = Command::new(EXECUTABLE);
     cmd.arg("--mcp-config")
-        .arg(claude_role_mcp_config_path(role))
-        .arg("--strict-mcp-config");
+        .arg(claude_role_mcp_config_path(role));
+    if isolation == ClaudeMcpIsolation::FerrusOnly {
+        cmd.arg("--strict-mcp-config");
+    }
     if let Some(model) = model {
         cmd.arg("--model").arg(model);
     }
@@ -120,7 +142,7 @@ mod tests {
 
     #[test]
     fn claude_supervisor_builds_interactive_command() {
-        let agent = Supervisor::new(None);
+        let agent = Supervisor::new(None, ClaudeMcpIsolation::MergeUser);
         let role_config = claude_role_mcp_config_path(ROLE_SUPERVISOR)
             .to_string_lossy()
             .into_owned();
@@ -131,13 +153,13 @@ mod tests {
                 })
                 .unwrap(),
             "claude",
-            &["--mcp-config", &role_config, "--strict-mcp-config", "plan"],
+            &["--mcp-config", &role_config, "plan"],
         );
     }
 
     #[test]
     fn claude_executor_builds_headless_command() {
-        let agent = Executor::new(None);
+        let agent = Executor::new(None, ClaudeMcpIsolation::MergeUser);
         let role_config = claude_role_mcp_config_path(ROLE_EXECUTOR)
             .to_string_lossy()
             .into_owned();
@@ -146,19 +168,13 @@ mod tests {
                 .spawn(AgentRunMode::Headless { prompt: "run" })
                 .unwrap(),
             "claude",
-            &[
-                "--mcp-config",
-                &role_config,
-                "--strict-mcp-config",
-                "-p",
-                "run",
-            ],
+            &["--mcp-config", &role_config, "-p", "run"],
         );
     }
 
     #[test]
     fn claude_model_override_is_part_of_spawned_command() {
-        let agent = Supervisor::new(Some("claude-opus-4-6"));
+        let agent = Supervisor::new(Some("claude-opus-4-6"), ClaudeMcpIsolation::MergeUser);
         let role_config = claude_role_mcp_config_path(ROLE_SUPERVISOR)
             .to_string_lossy()
             .into_owned();
@@ -170,7 +186,6 @@ mod tests {
             &[
                 "--mcp-config",
                 &role_config,
-                "--strict-mcp-config",
                 "--model",
                 "claude-opus-4-6",
                 "-p",
@@ -180,8 +195,43 @@ mod tests {
     }
 
     #[test]
+    fn claude_ferrus_only_mode_adds_strict_mcp_config() {
+        let role_config = claude_role_mcp_config_path(ROLE_SUPERVISOR)
+            .to_string_lossy()
+            .into_owned();
+        assert_program_and_args(
+            claude_command(
+                ROLE_SUPERVISOR,
+                AgentRunMode::Headless { prompt: "review" },
+                None,
+                ClaudeMcpIsolation::FerrusOnly,
+            ),
+            "claude",
+            &[
+                "--mcp-config",
+                &role_config,
+                "--strict-mcp-config",
+                "-p",
+                "review",
+            ],
+        );
+    }
+
+    #[test]
+    fn claude_role_mcp_config_paths_are_role_scoped() {
+        assert_eq!(
+            claude_role_mcp_config_path(ROLE_SUPERVISOR),
+            Path::new(".claude/mcp-supervisor.json")
+        );
+        assert_eq!(
+            claude_role_mcp_config_path(ROLE_EXECUTOR),
+            Path::new(".claude/mcp-executor.json")
+        );
+    }
+
+    #[test]
     fn claude_config_entry_uses_expected_args() {
-        let entry = Supervisor::new(Some("claude-opus-4-6"))
+        let entry = Supervisor::new(Some("claude-opus-4-6"), ClaudeMcpIsolation::MergeUser)
             .mcp_config_entry("supervisor", 2)
             .unwrap();
         assert!(!entry.command.is_empty());
@@ -205,7 +255,9 @@ mod tests {
 
     #[test]
     fn claude_executor_config_entry_uses_expected_args() {
-        let entry = Executor::new(None).mcp_config_entry("executor", 4).unwrap();
+        let entry = Executor::new(None, ClaudeMcpIsolation::MergeUser)
+            .mcp_config_entry("executor", 4)
+            .unwrap();
         assert!(!entry.command.is_empty());
         assert_eq!(
             entry.args,

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -158,7 +158,10 @@ pub fn parse_supervisor_agent(
     model: Option<&str>,
 ) -> Result<Arc<dyn SupervisorAgent>> {
     match agent_type {
-        claude::NAME => Ok(Arc::new(claude::Supervisor::new(model))),
+        claude::NAME => Ok(Arc::new(claude::Supervisor::new(
+            model,
+            crate::config::load_claude_mcp_isolation(),
+        ))),
         codex::NAME => Ok(Arc::new(codex::Supervisor::new(model))),
         qwen::NAME => Ok(Arc::new(qwen::Supervisor::new(model))),
         other => bail!(
@@ -178,7 +181,10 @@ pub fn parse_executor_agent(
     model: Option<&str>,
 ) -> Result<Arc<dyn ExecutorAgent>> {
     match agent_type {
-        claude::NAME => Ok(Arc::new(claude::Executor::new(model))),
+        claude::NAME => Ok(Arc::new(claude::Executor::new(
+            model,
+            crate::config::load_claude_mcp_isolation(),
+        ))),
         codex::NAME => Ok(Arc::new(codex::Executor::new(model))),
         qwen::NAME => Ok(Arc::new(qwen::Executor::new(model))),
         other => bail!(

--- a/src/cli/commands/register.rs
+++ b/src/cli/commands/register.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 
 use crate::agent_id::{ROLE_EXECUTOR, ROLE_SUPERVISOR, agent_id, mcp_server_name};
 use crate::agents::{McpConfigEntry, parse_executor_agent, parse_supervisor_agent};
-use crate::config::{HqRole, update_hq_agent_config};
+use crate::config::{HqRole, ensure_claude_mcp_isolation_default, update_hq_agent_config};
 
 #[derive(Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
 pub enum Agent {
@@ -91,6 +91,7 @@ fn config_entry(
 }
 
 async fn register_claude_code(role: &str, agent_name: &str, model: Option<&str>) -> Result<()> {
+    ensure_claude_mcp_isolation_default().await?;
     let dir = std::path::Path::new(".claude");
     tokio::fs::create_dir_all(dir).await?;
     let path = crate::agents::claude::claude_role_mcp_config_path(role);
@@ -567,6 +568,9 @@ mod tests {
         let _lock = cwd_test_mutex().lock().unwrap();
         let temp = tempfile::tempdir().unwrap();
         let _cwd_guard = CurrentDirGuard::change_to(temp.path());
+        tokio::fs::write("ferrus.toml", "[checks]\n[limits]\n")
+            .await
+            .unwrap();
 
         register_claude_code(ROLE_SUPERVISOR, crate::agents::claude::NAME, None)
             .await
@@ -593,6 +597,9 @@ mod tests {
         let _lock = cwd_test_mutex().lock().unwrap();
         let temp = tempfile::tempdir().unwrap();
         let _cwd_guard = CurrentDirGuard::change_to(temp.path());
+        tokio::fs::write("ferrus.toml", "[checks]\n[limits]\n")
+            .await
+            .unwrap();
 
         register_claude_code(ROLE_SUPERVISOR, crate::agents::claude::NAME, None)
             .await
@@ -635,5 +642,44 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("--supervisor-model requires --supervisor"));
+    }
+
+    #[tokio::test]
+    async fn claude_registration_sets_default_mcp_isolation_when_missing() {
+        let _lock = cwd_test_mutex().lock().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let _cwd_guard = CurrentDirGuard::change_to(temp.path());
+        tokio::fs::write("ferrus.toml", "[checks]\n[limits]\n")
+            .await
+            .unwrap();
+
+        register_claude_code(ROLE_SUPERVISOR, crate::agents::claude::NAME, None)
+            .await
+            .unwrap();
+
+        let ferrus_toml = tokio::fs::read_to_string("ferrus.toml").await.unwrap();
+        assert!(ferrus_toml.contains("[agents.claude]"));
+        assert!(ferrus_toml.contains("mcp_isolation = \"merge-user\""));
+    }
+
+    #[tokio::test]
+    async fn claude_registration_does_not_overwrite_existing_mcp_isolation() {
+        let _lock = cwd_test_mutex().lock().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let _cwd_guard = CurrentDirGuard::change_to(temp.path());
+        tokio::fs::write(
+            "ferrus.toml",
+            "[checks]\n[limits]\n[agents.claude]\nmcp_isolation = \"ferrus-only\"\n",
+        )
+        .await
+        .unwrap();
+
+        register_claude_code(ROLE_EXECUTOR, crate::agents::claude::NAME, None)
+            .await
+            .unwrap();
+
+        let ferrus_toml = tokio::fs::read_to_string("ferrus.toml").await.unwrap();
+        assert!(ferrus_toml.contains("mcp_isolation = \"ferrus-only\""));
+        assert!(!ferrus_toml.contains("mcp_isolation = \"merge-user\""));
     }
 }

--- a/src/config/claude.rs
+++ b/src/config/claude.rs
@@ -1,0 +1,57 @@
+use anyhow::{Context, Result};
+use toml_edit::{DocumentMut, Item, Table, value};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClaudeMcpIsolation {
+    MergeUser,
+    FerrusOnly,
+}
+
+pub fn load_claude_mcp_isolation() -> ClaudeMcpIsolation {
+    let Ok(contents) = std::fs::read_to_string("ferrus.toml") else {
+        return ClaudeMcpIsolation::MergeUser;
+    };
+    let Ok(value) = contents.parse::<toml::Value>() else {
+        return ClaudeMcpIsolation::MergeUser;
+    };
+    match value
+        .get("agents")
+        .and_then(|v| v.get("claude"))
+        .and_then(|v| v.get("mcp_isolation"))
+        .and_then(toml::Value::as_str)
+    {
+        Some("ferrus-only") => ClaudeMcpIsolation::FerrusOnly,
+        _ => ClaudeMcpIsolation::MergeUser,
+    }
+}
+
+pub async fn ensure_claude_mcp_isolation_default() -> Result<()> {
+    let contents = tokio::fs::read_to_string("ferrus.toml")
+        .await
+        .context("ferrus.toml not found — run `ferrus init` first")?;
+    let mut doc = contents
+        .parse::<DocumentMut>()
+        .context("Failed to parse ferrus.toml")?;
+
+    if !doc.contains_key("agents") {
+        doc["agents"] = Item::Table(Table::new());
+    }
+    let agents = doc["agents"]
+        .as_table_mut()
+        .ok_or_else(|| anyhow::anyhow!("ferrus.toml [agents] must be a table"))?;
+    if !agents.contains_key("claude") {
+        agents["claude"] = Item::Table(Table::new());
+    }
+    let claude = agents["claude"]
+        .as_table_mut()
+        .ok_or_else(|| anyhow::anyhow!("ferrus.toml [agents.claude] must be a table"))?;
+    if claude.contains_key("mcp_isolation") {
+        return Ok(());
+    }
+    claude["mcp_isolation"] = value("merge-user");
+
+    tokio::fs::write("ferrus.toml", doc.to_string())
+        .await
+        .context("Failed to write ferrus.toml")?;
+    Ok(())
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,6 +3,10 @@ use serde::Deserialize;
 use toml_edit::{DocumentMut, Item, Table, value};
 
 use crate::agents::{ExecutorAgent, SupervisorAgent, parse_executor_agent, parse_supervisor_agent};
+mod claude;
+pub use claude::{
+    ClaudeMcpIsolation, ensure_claude_mcp_isolation_default, load_claude_mcp_isolation,
+};
 
 #[derive(Debug)]
 #[allow(dead_code)]


### PR DESCRIPTION
### Motivation

- Provide a configurable MCP isolation mode for the Claude backend so Ferrus can choose whether to enforce strict MCP configs (`ferrus-only`) or merge with the user's config (`merge-user`).
- Persist a default isolation setting into `ferrus.toml` when registering Claude servers so new projects get a well-defined behavior.

### Description

- Introduce `src/config/claude.rs` with `ClaudeMcpIsolation` enum and functions `load_claude_mcp_isolation` and `ensure_claude_mcp_isolation_default` to read and set the default in `ferrus.toml`.
- Add an `mcp_isolation: ClaudeMcpIsolation` field to `claude::Supervisor` and `claude::Executor` and update their constructors to accept the setting.
- Thread the isolation value through `claude_command(...)` and add `--strict-mcp-config` only when `ClaudeMcpIsolation::FerrusOnly` is configured.
- Make agent construction use the configured default by calling `crate::config::load_claude_mcp_isolation()` in `parse_supervisor_agent` and `parse_executor_agent`.
- Call `ensure_claude_mcp_isolation_default()` during Claude registration to write the default `mcp_isolation = "merge-user"` into `ferrus.toml` if missing.
- Update and add unit and async tests to cover the new behavior, including tests for command argument shapes, role-scoped MCP config paths, default-setting behavior, and preserving existing configuration.

### Testing

- Ran the repository test suite with the added unit and `tokio` async tests covering Claude command construction and registration behavior, and they passed. 
- Added tests specifically asserting that `--strict-mcp-config` is present only in `FerrusOnly` mode, that role MCP config paths are role-scoped, and that `ferrus.toml` defaults are written or preserved; those tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f200d1bdcc8332a1041e9b3c40c2c7)