### PR TITLE
New /reset-spec command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferrus"
-version = "0.2.7-alpha.2"
+version = "0.2.7-alpha.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrus"
-version = "0.2.7-alpha.2"
+version = "0.2.7-alpha.3"
 edition = "2024"
 rust-version = "1.95.0"
 license = "Apache-2.0"

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -287,6 +287,7 @@ Set `RUST_LOG=ferrus=debug` (or `info`/`warn`) for verbose logs to stderr.
 | `/task --manual` | Define a free-form task without selected milestone context |
 | `/spec` | Draft, approve, and save a feature specification |
 | `/milestones` | Select the current spec and milestone |
+| `/reset-spec` | Clear the selected spec and milestone |
 | `/supervisor` | Open an interactive supervisor session (no initial prompt) |
 | `/executor` | Open an interactive executor session (no initial prompt) |
 | `/review` | Manually spawn supervisor in review mode (escape hatch) |

--- a/src/hq/commands.rs
+++ b/src/hq/commands.rs
@@ -44,6 +44,8 @@ pub enum ShellCommand {
     },
     /// Select the current spec and milestone without creating a task.
     Milestones,
+    /// Clear the selected spec and milestone.
+    ResetSpec,
     /// Draft and approve a feature specification with the supervisor.
     Spec,
     /// Open an interactive supervisor session (no initial prompt, no state requirement).
@@ -176,6 +178,13 @@ mod tests {
         assert!(matches!(
             parse_command("/milestones").unwrap(),
             ShellCommand::Milestones
+        ));
+    }
+    #[test]
+    fn parse_reset_spec() {
+        assert!(matches!(
+            parse_command("/reset-spec").unwrap(),
+            ShellCommand::ResetSpec
         ));
     }
     #[test]

--- a/src/hq/mod.rs
+++ b/src/hq/mod.rs
@@ -224,6 +224,7 @@ async fn dispatch(line: &str, ctx: &mut HqContext) -> Result<()> {
                 "  /task              Define a task from the selected milestone, then run executor→review loop\n",
                 "  /task --manual     Define a free-form task without selected milestone context\n",
                 "  /milestones        Select the current spec and milestone\n",
+                "  /reset-spec        Clear the selected spec and milestone\n",
                 "  /spec              Draft, approve, and save a feature specification\n",
                 "  /check             Run the Ferrus check gate deterministically from HQ\n",
                 "  /check --force     Run configured checks from HQ without state requirements\n",
@@ -252,6 +253,7 @@ async fn dispatch(line: &str, ctx: &mut HqContext) -> Result<()> {
         ShellCommand::Plan => ctx.plan().await?,
         ShellCommand::Task { manual } => ctx.task(manual, true).await?,
         ShellCommand::Milestones => ctx.milestones().await?,
+        ShellCommand::ResetSpec => ctx.reset_spec_selection().await?,
         ShellCommand::Spec => ctx.spec().await?,
         ShellCommand::Supervisor => ctx.supervisor_interactive().await?,
         ShellCommand::Executor => ctx.executor_interactive().await?,
@@ -1168,6 +1170,22 @@ impl HqContext {
                 }
             }
         }
+    }
+
+    async fn reset_spec_selection(&mut self) -> Result<()> {
+        let mut state = store::read_state().await?;
+        if state.selected_spec.is_none() && state.selected_milestone.is_none() {
+            self.display
+                .muted("No selected spec or milestone to reset.");
+            return Ok(());
+        }
+
+        state.clear_selected_spec_and_milestone();
+        store::write_state(&state).await?;
+
+        self.display
+            .muted("Selected spec reset. /task will use manual task definition.");
+        Ok(())
     }
 
     async fn milestones(&mut self) -> Result<()> {

--- a/src/hq/tui.rs
+++ b/src/hq/tui.rs
@@ -27,6 +27,7 @@ const COMMANDS: &[(&str, &str)] = &[
     ("/plan", "spawn supervisor, plan a task"),
     ("/task", "define a task and run executor then review"),
     ("/milestones", "select current spec and milestone"),
+    ("/reset-spec", "clear selected spec and milestone"),
     ("/spec", "draft and save an approved feature spec"),
     ("/check", "run the Ferrus check gate from HQ"),
     ("/supervisor", "open an interactive supervisor session"),
@@ -1932,7 +1933,7 @@ mod tui_tests {
                 .iter()
                 .map(|(cmd, _)| *cmd)
                 .collect::<Vec<_>>(),
-            vec!["/resume", "/review", "/reset", "/register"]
+            vec!["/reset-spec", "/resume", "/review", "/reset", "/register"]
         );
     }
 
@@ -1970,6 +1971,7 @@ mod tui_tests {
         assert!(commands.contains(&"/check"));
         assert!(commands.contains(&"/model"));
         assert!(commands.contains(&"/resume"));
+        assert!(commands.contains(&"/reset-spec"));
         assert!(commands.contains(&"/supervisor"));
         assert!(commands.contains(&"/executor"));
         assert!(!commands.contains(&"/execute"));

--- a/src/specs.rs
+++ b/src/specs.rs
@@ -343,6 +343,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolve_selected_treats_missing_spec_and_milestone_as_no_selection() {
+        let state = StateData::default();
+
+        let selected = resolve_selected(&state).await.unwrap();
+
+        assert_eq!(selected, SelectedMilestoneState::MissingSelection);
+    }
+
+    #[tokio::test]
+    async fn resolve_selected_treats_partial_selection_as_no_selection() {
+        let state = StateData {
+            selected_spec: Some("docs/specs/spec.md".to_string()),
+            ..StateData::default()
+        };
+
+        let selected = resolve_selected(&state).await.unwrap();
+
+        assert_eq!(selected, SelectedMilestoneState::MissingSelection);
+    }
+
+    #[tokio::test]
     async fn completes_task_milestone_and_advances_when_selection_matches_origin() {
         let (dir, path) = write_test_spec();
         let mut state = StateData {

--- a/src/state/machine.rs
+++ b/src/state/machine.rs
@@ -133,6 +133,11 @@ impl StateData {
         self.pending_task_milestone = milestone;
     }
 
+    pub fn clear_selected_spec_and_milestone(&mut self) {
+        self.selected_spec = None;
+        self.selected_milestone = None;
+    }
+
     /// True if a non-expired lease exists (`lease_until` is set and in the future).
     #[allow(dead_code)]
     pub fn is_claimed(&self) -> bool {
@@ -365,7 +370,7 @@ impl StateData {
                 state: self.state.clone(),
             });
         }
-        *self = Self::default();
+        self.force_reset();
         Ok(())
     }
 }
@@ -513,6 +518,8 @@ mod tests {
     #[test]
     fn reset_from_failed() {
         let mut s = idle();
+        s.selected_spec = Some("docs/specs/spec.md".to_string());
+        s.selected_milestone = Some("m1.0".to_string());
         s.create_task().unwrap();
         for i in 1..=5 {
             let _ = s.check_failed(format!("fail {i}"), 5);
@@ -521,6 +528,33 @@ mod tests {
         s.reset().unwrap();
         assert_eq!(s.state, TaskState::Idle);
         assert_eq!(s.check_retries, 0);
+        assert_eq!(s.selected_spec.as_deref(), Some("docs/specs/spec.md"));
+        assert_eq!(s.selected_milestone.as_deref(), Some("m1.0"));
+    }
+
+    #[test]
+    fn clear_selected_spec_and_milestone_only_clears_selection() {
+        let mut s = StateData {
+            selected_spec: Some("docs/specs/spec.md".to_string()),
+            selected_milestone: Some("m1.0".to_string()),
+            pending_task_spec: Some("docs/specs/pending.md".to_string()),
+            pending_task_milestone: Some("m2.0".to_string()),
+            task_spec: Some("docs/specs/task.md".to_string()),
+            task_milestone: Some("m3.0".to_string()),
+            ..StateData::default()
+        };
+
+        s.clear_selected_spec_and_milestone();
+
+        assert!(s.selected_spec.is_none());
+        assert!(s.selected_milestone.is_none());
+        assert_eq!(
+            s.pending_task_spec.as_deref(),
+            Some("docs/specs/pending.md")
+        );
+        assert_eq!(s.pending_task_milestone.as_deref(), Some("m2.0"));
+        assert_eq!(s.task_spec.as_deref(), Some("docs/specs/task.md"));
+        assert_eq!(s.task_milestone.as_deref(), Some("m3.0"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Added a new command `/reset-spec` that resets the current selected spec and milestone.

## Type
- [ ] Bug fix
- [ ] Feature
- [x] Enhancement
- [ ] Performance
- [ ] Documentation
- [ ] Refactor
- [ ] Security
- [ ] Breaking change

## Workflow impact (if applicable)
Does this change affect the Supervisor → Executor → Reviewer flow?

- [x] No impact
- [ ] Minor change (does not alter lifecycle semantics)
- [ ] Changes behavior of an existing step
- [ ] Introduces new state/transition

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)
