### PR TITLE
Feat/structure polishing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,18 @@ All three checks must pass before submitting: `clippy -D warnings`, `fmt --check
 ```
 src/
   main.rs                    # CLI entry, tracing init, HQ logger
-  cli/                       # clap subcommands (init, serve, register)
-  config/mod.rs              # Deserialize ferrus.toml (ChecksConfig, LimitsConfig, LeaseConfig, HqConfig)
+  cli/                       # clap entry and command implementations (init, serve, register)
+  config/mod.rs              # Deserialize/update ferrus.toml (ChecksConfig, LimitsConfig, LeaseConfig, SpecConfig, HqConfig)
+  config/claude.rs           # Claude MCP isolation config helpers
+  templates.rs               # Embedded Markdown templates written by init/resource fallback
+  specs.rs                   # Spec discovery, milestone parsing, selected milestone resolution
+  agent_id.rs                # Stable agent IDs and MCP server names
+  agents/                    # Agent launcher/config adapters for Claude Code, Codex, Qwen Code
+  agents/mod.rs              # SupervisorAgent/ExecutorAgent traits, AgentRunMode, MCP config entry helpers, agent parsing
+  agents/claude/mod.rs       # Claude Code launchers, model override handling, MCP isolation, role-scoped config paths
+  agents/codex/mod.rs        # Codex launchers, stdin prompt transport, TOML MCP config and tool approvals
+  agents/qwen/mod.rs         # Qwen Code launchers, model override handling, JSON settings tool approvals
+  platform/                  # OS-specific process, shell, and parent-lifecycle helpers
   state/machine.rs           # TaskState enum + StateData + transition methods + lease helpers
   state/store.rs             # Async read/write of .ferrus/ files; open_lock_file, claim_state
   state/agents.rs            # AgentEntry, AgentsRegistry — .ferrus/agents.json lifecycle tracking
@@ -37,12 +47,12 @@ src/
   checks/runner.rs           # Spawn check subprocesses, collect output
   hq/mod.rs                  # HQ entry point; HqContext; tokio::select! loop; transition_action
   hq/state_watcher.rs        # Background task: polls STATE.json every 250ms, watch channel
-  hq/tui.rs                  # Terminal UI (crossterm): App event loop, UiMessage, StatusSnapshot; autocomplete, command history, spec/milestone status line, confirmation/selection dialogs; double-Ctrl+C-to-quit (2-second window)
+  hq/tui.rs                  # Terminal UI (crossterm): App event loop, UiMessage, StatusSnapshot; autocomplete, command history, spec/milestone status line, confirmation/selection dialogs, AwaitingHuman answer hint; double-Ctrl+C-to-quit
   hq/commands.rs             # ShellCommand enum, parse_command() via clap + shlex
   hq/display.rs              # Display wrapper: sends UiMessage to TUI channel (info, error, transition, status, suspend, resume, confirm)
   hq/agent_manager.rs        # agent spawn helpers (headless for executor, reviewer, consultant); HeadlessHandle; agents.json updates
   server/mod.rs              # neva App setup; constructs agent_id, wires closures
-  server/tools/              # One file per MCP tool (one module = one tool)
+  server/tools/              # One file per MCP tool (one module = one tool); check_gate.rs is the shared check runner/report helper
   server/resources.rs        # MCP resource handler (ferrus://{file})
   server/prompts.rs          # MCP prompt handlers
 ```
@@ -58,6 +68,12 @@ src/
 **File locking**: `wait_for_task`, `wait_for_review`, and `/heartbeat` acquire an exclusive `flock` on `.ferrus/STATE.lock` (not `STATE.json`) for their read-check-write cycle. Use `store::open_lock_file()` + `tokio::task::spawn_blocking` for the blocking lock call.
 
 **Spec selection**: `STATE.json` stores `selected_spec` and `selected_milestone` as UI references only. Active task progress uses `task_spec` and `task_milestone`, copied from `pending_task_*` when `/create_task` succeeds. Milestone display text is resolved from the spec Markdown by milestone `ID`. Keep milestone IDs stable across title edits.
+
+**Agent adapters**: keep backend-specific CLI behavior inside `src/agents/{claude,codex,qwen}`. Shared orchestration should depend on the `SupervisorAgent` and `ExecutorAgent` traits, not on a concrete agent CLI. When adding an agent, implement both role adapters, model normalization, headless prompt transport if needed, version/config entry behavior, registration wiring, and focused tests.
+
+**HQ checks**: `/check` calls the same MCP check handler as an Executor and therefore updates retry state. `/check --force` runs configured commands directly from HQ and does not modify `STATE.json`.
+
+**HQ reset vs MCP reset**: HQ `/reset` force-resets from any state after confirmation when active agents may be running, clears task/answer/consultation files, and preserves selected spec/milestone. The MCP `/reset` tool is only valid from `Failed`.
 
 ## Ferrus Executor
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,9 @@ ferrus register [--supervisor <agent>] [--supervisor-model <model>] [--executor 
 | `/task --manual` | Define a free-form task without selected milestone context |
 | `/spec` | Draft, approve, and save a feature specification |
 | `/milestones` | Select the current spec and milestone |
+| `/reset-spec` | Clear the selected spec and milestone |
+| `/check` | Run the Ferrus check gate from HQ, using the normal task-state rules |
+| `/check --force` | Run configured checks from HQ without modifying state |
 | `/supervisor` | Open an interactive supervisor session (no initial prompt, no state requirement) |
 | `/executor` | Open an interactive executor session (no initial prompt, no state requirement) |
 | `/resume` | Manually resume the executor headlessly; also recovers Consultation by relaunching both consultant and executor |
@@ -58,8 +61,9 @@ ferrus register [--supervisor <agent>] [--supervisor-model <model>] [--executor 
 | `/stop` | Stop all running agent sessions (prompts for confirmation) |
 | `/reset` | Reset state to Idle and clear task files (prompts for confirmation) |
 | `/init [--agents-path]` | Initialize ferrus in the current directory |
-| `/register` | Register agent configs (same as `ferrus register`) |
-| `/model` | Update the supervisor or executor model override |
+| `/register [--supervisor <agent>] [--executor <agent>]` | Register Claude Code or Codex configs from HQ |
+| `/model <supervisor|executor> <model>` | Update the supervisor or executor model override |
+| `/model <supervisor|executor> --clear` | Clear the supervisor or executor model override |
 | `/help` | List all HQ commands |
 | `/quit` | Exit HQ |
 
@@ -124,6 +128,7 @@ model = ""             # optional override; empty = agent default
 | `/review_pending` | Reviewing | — | Read task + context for review |
 | `/approve` | Reviewing | Complete | Accept the submission |
 | `/reject` | Reviewing | Addressing | Reject with notes; resets Executor retry counter |
+| `/respond_consult` | Consultation | — | Record the Supervisor consultation response in `CONSULT_RESPONSE.md` |
 
 ### Executor tools
 
@@ -141,7 +146,6 @@ model = ""             # optional override; empty = agent default
 | Tool | From state | To state | Description |
 |---|---|---|---|
 | `/ask_human` | Executing, Addressing, Consultation, Reviewing | AwaitingHuman | Last-resort human fallback. Write question to QUESTION.md; agent must immediately call `/wait_for_answer` (executor) or wait for HQ to answer |
-| `/respond_consult` | Consultation | — | Record the Supervisor consultation response in `CONSULT_RESPONSE.md` |
 | `/answer` | AwaitingHuman | (previous state) | Provide answer to a pending question; restores previous state |
 | `/heartbeat` | any claimed | — | Renew lease; call every ~30s while working |
 | `/status` | any | — | Print current state + retry counters |
@@ -206,6 +210,7 @@ Executor verification is TDD-friendly: `/check` can be run as often as needed du
 |---|---|
 | `STATE.json` | Current `TaskState`, lease fields (`claimed_by`, `lease_until`, `last_heartbeat`), retry/cycle counters, failure reason, schema version, last-write timestamp and PID |
 | `STATE.lock` | Advisory lock file for atomic claiming (do not delete) |
+| `agents.json` | Runtime registry for agent sessions, statuses, PIDs, and log ownership |
 | `TASK.md` | Task description written by Supervisor |
 | `REVIEW.md` | Supervisor rejection notes |
 | `SUBMISSION.md` | Executor's submission notes (summary, verification steps, known limitations) |
@@ -225,8 +230,18 @@ Executor verification is TDD-friendly: `/check` can be run as often as needed du
 ```
 src/
   main.rs                    # CLI entry, tracing init, HQ logger
-  cli/                       # clap subcommands (init, serve, register)
-  config/mod.rs              # Deserialize ferrus.toml (ChecksConfig, LimitsConfig, LeaseConfig, HqConfig)
+  cli/                       # clap entry and command implementations (init, serve, register)
+  config/mod.rs              # Deserialize/update ferrus.toml (ChecksConfig, LimitsConfig, LeaseConfig, SpecConfig, HqConfig)
+  config/claude.rs           # Claude MCP isolation config helpers
+  templates.rs               # Embedded Markdown templates written by init/resource fallback
+  specs.rs                   # Spec discovery, milestone parsing, selected milestone resolution
+  agent_id.rs                # Stable agent IDs and MCP server names
+  agents/                    # Agent launcher/config adapters for Claude Code, Codex, Qwen Code
+  agents/mod.rs              # SupervisorAgent/ExecutorAgent traits, AgentRunMode, MCP config entry helpers, agent parsing
+  agents/claude/mod.rs       # Claude Code launchers, model override handling, MCP isolation, role-scoped config paths
+  agents/codex/mod.rs        # Codex launchers, stdin prompt transport, TOML MCP config and tool approvals
+  agents/qwen/mod.rs         # Qwen Code launchers, model override handling, JSON settings tool approvals
+  platform/                  # OS-specific process, shell, and parent-lifecycle helpers
   state/machine.rs           # TaskState enum + StateData + transition methods + lease helpers
   state/store.rs             # Async read/write of .ferrus/ files; open_lock_file, claim_state
   state/agents.rs            # AgentEntry, AgentsRegistry — .ferrus/agents.json lifecycle tracking
@@ -234,21 +249,27 @@ src/
   checks/runner.rs           # Spawn check subprocesses, collect output
   hq/mod.rs                  # HQ entry point; HqContext; tokio::select! loop; transition_action
   hq/state_watcher.rs        # Background task: polls STATE.json every 250ms, sends on watch channel
-  hq/tui.rs                  # Terminal UI (crossterm): App event loop, UiMessage, StatusSnapshot; autocomplete, command history, status line, confirmation dialogs
+  hq/tui.rs                  # Terminal UI (crossterm): App event loop, UiMessage, StatusSnapshot; autocomplete, command history, spec/milestone status line, confirmation/selection dialogs, AwaitingHuman answer hint
   hq/commands.rs             # ShellCommand enum, parse_command() via clap + shlex
   hq/display.rs              # Display wrapper: sends UiMessage to TUI channel (info, error, transition, status, suspend, resume, confirm)
   hq/agent_manager.rs        # agent spawn helpers (headless for executor, reviewer, consultant); HeadlessHandle; agents.json updates
   server/mod.rs              # neva App setup; constructs agent_id, wires closures
-  server/tools/              # One file per MCP tool
+  server/tools/              # One file per MCP tool; check_gate.rs is the shared check runner/report helper
+    answer.rs                # /answer — writes ANSWER.md and restores AwaitingHuman state
     heartbeat.rs             # /heartbeat — lease renewal
     wait_for_task.rs         # /wait_for_task — atomic claim loop (STATE.lock + fs2)
     wait_for_review.rs       # /wait_for_review — same pattern for Supervisor
+    check_gate.rs            # Shared final/diagnostic check execution and report formatting
     consult.rs               # /consult — writes CONSULT_REQUEST.md and transitions to Consultation
     respond_consult.rs       # /respond_consult — records the supervisor consultation response
     wait_for_consult.rs      # /wait_for_consult — polls CONSULT_RESPONSE.md, restores state, returns answer
     ask_human.rs             # /ask_human — writes QUESTION.md, transitions to AwaitingHuman
     wait_for_answer.rs       # /wait_for_answer — polls ANSWER.md, restores state, returns answer
 ```
+
+## Agent Adapter Pattern
+
+Backend-specific CLI behavior belongs in `src/agents/{claude,codex,qwen}`. Shared orchestration should use the `SupervisorAgent` and `ExecutorAgent` traits from `src/agents/mod.rs` instead of matching on a concrete CLI. New agents need both role adapters, model normalization, headless prompt transport if needed, version/config entry behavior, registration wiring, and focused tests.
 
 <!-- ferrus-supervisor-instructions -->
 ## Ferrus Supervisor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferrus"
-version = "0.2.7-alpha.3"
+version = "0.2.7-alpha.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrus"
-version = "0.2.7-alpha.3"
+version = "0.2.7-alpha.4"
 edition = "2024"
 rust-version = "1.95.0"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Ferrus works with existing coding agents:
 
 Agents are treated as interchangeable workers — ferrus provides the runtime, coordination, and state.
 
+Internally, agent support is normalized through `src/agents/`: `mod.rs` defines the shared Supervisor/Executor contracts and MCP config entry shape, while `claude/`, `codex/`, and `qwen/` adapt each CLI's launch flags, model overrides, headless prompt transport, and local permission/config conventions.
+
 > 💡 **Status**: ferrus is currently in alpha and not ready for production.
 
 [Tutorial](https://romanemreis.github.io/ferrus-docs/) | [Roadmap](https://github.com/RomanEmreis/ferrus/blob/main/docs/milestones.md)
@@ -98,6 +100,9 @@ On Linux and macOS for `x86_64` and `aarch64`/`arm64`, `install.sh` downloads th
 | `/task --manual` | Define a free-form task without selected milestone context |
 | `/spec` | Draft, approve, and save a feature specification |
 | `/milestones` | Select the current spec and milestone |
+| `/reset-spec` | Clear the selected spec and milestone |
+| `/check` | Run the Ferrus check gate from HQ, using the normal task-state rules |
+| `/check --force` | Run configured checks from HQ without modifying state |
 | `/supervisor` | Open an interactive supervisor session (no initial prompt) |
 | `/executor` | Open an interactive executor session (no initial prompt) |
 | `/resume` | Manually resume the executor headlessly; also recovers Consultation by relaunching both supervisor and executor |
@@ -107,8 +112,9 @@ On Linux and macOS for `x86_64` and `aarch64`/`arm64`, `install.sh` downloads th
 | `/stop` | Stop all running agent sessions (prompts for confirmation) |
 | `/reset` | Reset state to Idle and clear task files (prompts for confirmation) |
 | `/init [--agents-path]` | Initialize ferrus in the current directory |
-| `/register` | Register agent configs (same as `ferrus register`) |
-| `/model` | Update the supervisor or executor model override |
+| `/register [--supervisor <agent>] [--executor <agent>]` | Register Claude Code or Codex configs from HQ |
+| `/model <supervisor|executor> <model>` | Update the supervisor or executor model override |
+| `/model <supervisor|executor> --clear` | Clear the supervisor or executor model override |
 | `/help` | List all HQ commands |
 | `/quit` | Exit HQ |
 
@@ -151,7 +157,7 @@ Idle
                    └─► Reviewing            ← submit (final check passed)
 ```
 
-Any active Executor work state (Executing, Addressing, Checking) can pause to `Consultation` via `/consult`. HQ spawns the configured Supervisor in consultation mode, and the executor immediately calls `/wait_for_consult` to block until the Supervisor answers via `/respond_consult`.
+Any active Executor work state (Executing, Addressing) can pause to `Consultation` via `/consult`. HQ spawns the configured Supervisor in consultation mode, and the executor immediately calls `/wait_for_consult` to block until the Supervisor answers via `/respond_consult`.
 
 Any active state, including `Consultation`, can pause to `AwaitingHuman` via `/ask_human`. The agent immediately calls `/wait_for_answer` to block until the human responds. The human types their answer in the HQ terminal (raw text, no slash prefix). `/wait_for_answer` restores the previous state and returns the answer.
 
@@ -166,8 +172,9 @@ Any active state, including `Consultation`, can pause to `AwaitingHuman` via `/a
 
 Scaffolds ferrus in the current project (default `--agents-path .agents`):
 
-- Creates `ferrus.toml` with default check commands and limits
+- Creates `ferrus.toml` with default limits and an empty check command list
 - Creates `.ferrus/` runtime directory with all state files and `logs/`
+- Creates `docs/specs/` for approved feature specifications
 - Creates skill files agents load to understand their role:
   - `<agents-path>/skills/ferrus/SKILL.md` — general overview
   - `<agents-path>/skills/ferrus-supervisor/SKILL.md` + `ROLE.md`
@@ -184,13 +191,13 @@ Starts the agent coordination server on stdio. Agents load this as an MCP server
 | `executor` | `wait_for_task`, `check`, `consult`, `submit`, `wait_for_consult`, `wait_for_answer`, `ask_human`, `answer`, `status`, `reset`, `heartbeat` |
 | *(omitted)* | All tools |
 
-### `ferrus register --supervisor <agent> [--supervisor-model <model>] --executor <agent> [--executor-model <model>]`
+### `ferrus register [--supervisor <agent>] [--supervisor-model <model>] [--executor <agent>] [--executor-model <model>]`
 
-Writes agent config files so they automatically load `ferrus serve` as a tool server, and adds only the selected agents' local files to `.gitignore`. Supported agents:
+Writes agent config files so they automatically load `ferrus serve` as a tool server, and adds only the selected agents' local files to `.gitignore`. At least one of `--supervisor` or `--executor` is required; each model flag requires the matching role flag. Supported agents:
 
 | Agent | Config written |
 |---|---|
-| `claude-code` | `.mcp.json` + `.claude/settings.local.json` permissions |
+| `claude-code` | `.claude/mcp-supervisor.json` or `.claude/mcp-executor.json` + `.claude/settings.local.json` permissions |
 | `codex` | `.codex/config.toml` |
 | `qwen-code` | `.qwen/settings.json` |
 
@@ -238,6 +245,7 @@ Check commands run in the directory where `ferrus serve` was started. Full outpu
 |---|---|
 | `STATE.json` | Current state, lease fields, retry/cycle counters, schema version, timestamp |
 | `STATE.lock` | Advisory lock file for atomic claiming (do not delete) |
+| `agents.json` | Runtime registry for agent sessions, statuses, PIDs, and log ownership |
 | `TASK.md` | Task description written by Supervisor |
 | `REVIEW.md` | Supervisor rejection notes |
 | `SUBMISSION.md` | Executor submission notes |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ferrus
 
-[![Ferrus version](https://img.shields.io/badge/ferrus-0.2.7--alpha.3-orange)](https://crates.io/crates/ferrus)
+[![Ferrus version](https://img.shields.io/badge/ferrus-0.2.7--alpha.4-orange)](https://crates.io/crates/ferrus)
 [![Rust version](https://img.shields.io/badge/rustc-1.95+-964B00)](https://releases.rs/docs/1.95.0/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/RomanEmreis/ferrus/blob/main/LICENSE)
 [![Rust](https://github.com/RomanEmreis/ferrus/actions/workflows/rust.yml/badge.svg)](https://github.com/RomanEmreis/ferrus/actions/workflows/rust.yml)

--- a/src/hq/state_watcher.rs
+++ b/src/hq/state_watcher.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use chrono::{DateTime, Utc};
 use tokio::sync::watch;
@@ -26,6 +26,36 @@ pub struct WatchedState {
     pub selected_milestone_display: Option<String>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SelectedDisplayCacheKey {
+    selected_spec: Option<String>,
+    selected_milestone: Option<String>,
+    spec_fingerprint: Option<(Option<SystemTime>, u64)>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct SelectedDisplayCache {
+    key: Option<SelectedDisplayCacheKey>,
+    value: (Option<String>, Option<String>),
+}
+
+impl SelectedDisplayCache {
+    async fn get(&mut self, state: &StateData) -> (Option<String>, Option<String>) {
+        let key = SelectedDisplayCacheKey {
+            selected_spec: state.selected_spec.clone(),
+            selected_milestone: state.selected_milestone.clone(),
+            spec_fingerprint: selected_spec_fingerprint(state).await,
+        };
+
+        if self.key.as_ref() != Some(&key) {
+            self.value = selected_milestone_display(state).await;
+            self.key = Some(key);
+        }
+
+        self.value.clone()
+    }
+}
+
 /// Poll STATE.json every 250 ms and refresh elapsed timers every second.
 ///
 /// `updated_at` is the source of truth for how long the current state has been
@@ -36,6 +66,7 @@ pub async fn watch(tx: watch::Sender<Option<WatchedState>>) {
     let mut last_sent_state_elapsed_secs = None;
     let mut last_sent_task_elapsed_secs = None;
     let mut task_started_at = None;
+    let mut selected_display_cache = SelectedDisplayCache::default();
 
     loop {
         tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
@@ -91,7 +122,7 @@ pub async fn watch(tx: watch::Sender<Option<WatchedState>>) {
             last_sent_task_elapsed_secs = task_elapsed_secs;
             last_state = Some(state.clone());
             let (selected_spec_display, selected_milestone_display) =
-                selected_milestone_display(&state).await;
+                selected_display_cache.get(&state).await;
             let _ = tx.send(Some(WatchedState {
                 state,
                 state_elapsed,
@@ -101,6 +132,16 @@ pub async fn watch(tx: watch::Sender<Option<WatchedState>>) {
             }));
         }
     }
+}
+
+async fn selected_spec_fingerprint(state: &StateData) -> Option<(Option<SystemTime>, u64)> {
+    let path = state.selected_spec.as_deref()?.trim();
+    if path.is_empty() {
+        return None;
+    }
+
+    let metadata = tokio::fs::metadata(path).await.ok()?;
+    Some((metadata.modified().ok(), metadata.len()))
 }
 
 async fn selected_milestone_display(state: &StateData) -> (Option<String>, Option<String>) {

--- a/src/hq/tui.rs
+++ b/src/hq/tui.rs
@@ -515,6 +515,7 @@ struct TerminalUi {
     prompt_visible: bool,
     prompt_lines: u16,
     prompt_cursor_row: u16,
+    prompt_cursor_col: u16,
     lower_lines: u16,
 }
 
@@ -557,6 +558,7 @@ pub async fn run_tui(
         prompt_visible: false,
         prompt_lines: 0,
         prompt_cursor_row: 0,
+        prompt_cursor_col: 0,
         lower_lines: 0,
     };
     redraw_live_area(&mut stdout, &app, &mut ui)?;
@@ -604,7 +606,7 @@ pub async fn run_tui(
                 {
                     app.ctrl_c_pending = false;
                     app.ctrl_c_at = None;
-                    if !app.suspended {
+                    if !app.suspended && !refresh_status_line(&mut stdout, &app, &ui)? {
                         clear_live_area(&mut stdout, &ui)?;
                         redraw_live_area(&mut stdout, &app, &mut ui)?;
                     }
@@ -623,7 +625,7 @@ pub async fn run_tui(
                     next.directory = directory;
                     next.branch = branch;
                     app.status = next;
-                    if !app.suspended {
+                    if !app.suspended && !refresh_status_line(&mut stdout, &app, &ui)? {
                         clear_live_area(&mut stdout, &ui)?;
                         redraw_live_area(&mut stdout, &app, &mut ui)?;
                     }
@@ -849,7 +851,7 @@ fn handle_message(
                 next.branch = app.status.branch.clone();
             }
             app.status = next;
-            if !app.suspended {
+            if !app.suspended && !refresh_status_line(stdout, app, ui)? {
                 clear_live_area(stdout, ui)?;
                 redraw_live_area(stdout, app, ui)?;
             }
@@ -874,6 +876,7 @@ fn handle_message(
             ui.prompt_visible = false;
             ui.prompt_lines = 0;
             ui.prompt_cursor_row = 0;
+            ui.prompt_cursor_col = 0;
             ui.lower_lines = 0;
             redraw_live_area(stdout, app, ui)?;
             return Ok(true);
@@ -1073,9 +1076,56 @@ fn redraw_live_area(stdout: &mut Stdout, app: &App, ui: &mut TerminalUi) -> Resu
     ui.prompt_visible = true;
     ui.prompt_lines = prompt_lines;
     ui.prompt_cursor_row = prompt_cursor_row;
+    ui.prompt_cursor_col = prompt_cursor_col;
     ui.lower_lines = lower_lines.len() as u16;
     stdout.flush()?;
     Ok(())
+}
+
+fn refresh_status_line(stdout: &mut Stdout, app: &App, ui: &TerminalUi) -> Result<bool> {
+    let Some(move_down) = status_line_refresh_offset(app, ui) else {
+        return Ok(false);
+    };
+
+    let width = terminal_width() as usize;
+    queue!(
+        stdout,
+        MoveDown(move_down),
+        MoveToColumn(0),
+        Clear(ClearType::UntilNewLine)
+    )?;
+    print_live_area_line(
+        stdout,
+        &LiveAreaLine::Status,
+        app.ctrl_c_pending,
+        &app.status,
+        app.debug,
+        width,
+    )?;
+    queue!(
+        stdout,
+        MoveUp(move_down),
+        MoveToColumn(ui.prompt_cursor_col)
+    )?;
+    stdout.flush()?;
+    Ok(true)
+}
+
+fn status_line_refresh_offset(app: &App, ui: &TerminalUi) -> Option<u16> {
+    if !ui.prompt_visible
+        || ui.prompt_lines == 0
+        || ui.lower_lines != 1
+        || app.selection.is_some()
+        || app.completion_popup_visible()
+    {
+        return None;
+    }
+
+    Some(
+        ui.prompt_lines
+            .saturating_sub(ui.prompt_cursor_row.saturating_add(1))
+            + 2,
+    )
 }
 
 fn print_message_and_restore_prompt(
@@ -1092,6 +1142,7 @@ fn print_message_and_restore_prompt(
     ui.prompt_visible = false;
     ui.prompt_lines = 0;
     ui.prompt_cursor_row = 0;
+    ui.prompt_cursor_col = 0;
     ui.lower_lines = 0;
     redraw_live_area(stdout, app, ui)
 }
@@ -2002,6 +2053,37 @@ mod tui_tests {
         assert_eq!(prompt.lines, vec!["abcd", ""]);
         assert_eq!(prompt.cursor_row, 1);
         assert_eq!(prompt.cursor_col, 2);
+    }
+
+    #[test]
+    fn status_line_refresh_offset_targets_status_line_below_prompt() {
+        let app = App::new();
+        let ui = TerminalUi {
+            prompt_visible: true,
+            prompt_lines: 3,
+            prompt_cursor_row: 1,
+            prompt_cursor_col: 5,
+            lower_lines: 1,
+        };
+
+        assert_eq!(status_line_refresh_offset(&app, &ui), Some(3));
+    }
+
+    #[test]
+    fn status_line_refresh_offset_skips_completion_popup() {
+        let mut app = App::new();
+        app.input = "/".into();
+        app.cursor_pos = app.input.len();
+        app.next_completion();
+        let ui = TerminalUi {
+            prompt_visible: true,
+            prompt_lines: 1,
+            prompt_cursor_row: 0,
+            prompt_cursor_col: 2,
+            lower_lines: 3,
+        };
+
+        assert_eq!(status_line_refresh_offset(&app, &ui), None);
     }
 
     #[test]

--- a/src/hq/tui.rs
+++ b/src/hq/tui.rs
@@ -569,15 +569,16 @@ pub async fn run_tui(
                 match maybe_event {
                     Some(Ok(event)) => handle_event(event, &mut app, &cmd_tx, &mut stdout, &mut ui)?,
                     Some(Err(err)) => {
+                        let line = TranscriptLine {
+                            text: format!("Event error: {err}"),
+                            kind: TranscriptKind::Error,
+                            continuation: false,
+                        };
                         print_message_and_restore_prompt(
                             &mut stdout,
                             &app,
                             &mut ui,
-                            vec![TranscriptLine {
-                                text: format!("Event error: {err}"),
-                                kind: TranscriptKind::Error,
-                                continuation: false,
-                            }],
+                            std::slice::from_ref(&line),
                         )?;
                     }
                     None => app.should_quit = true,
@@ -805,8 +806,8 @@ fn handle_message(
     match msg {
         UiMessage::Info(text) => {
             let lines = split_transcript(&text, TranscriptKind::Info);
-            app.messages.extend(lines.clone());
-            print_message_and_restore_prompt(stdout, app, ui, lines)?;
+            app.messages.extend(lines.iter().cloned());
+            print_message_and_restore_prompt(stdout, app, ui, &lines)?;
         }
         UiMessage::Tip(text) => {
             let line = TranscriptLine {
@@ -815,17 +816,17 @@ fn handle_message(
                 continuation: false,
             };
             app.messages.push(line.clone());
-            print_message_and_restore_prompt(stdout, app, ui, vec![line])?;
+            print_message_and_restore_prompt(stdout, app, ui, std::slice::from_ref(&line))?;
         }
         UiMessage::Muted(text) => {
             let lines = split_transcript(&text, TranscriptKind::Muted);
-            app.messages.extend(lines.clone());
-            print_message_and_restore_prompt(stdout, app, ui, lines)?;
+            app.messages.extend(lines.iter().cloned());
+            print_message_and_restore_prompt(stdout, app, ui, &lines)?;
         }
         UiMessage::Error(text) => {
             let lines = split_transcript(&text, TranscriptKind::Error);
-            app.messages.extend(lines.clone());
-            print_message_and_restore_prompt(stdout, app, ui, lines)?;
+            app.messages.extend(lines.iter().cloned());
+            print_message_and_restore_prompt(stdout, app, ui, &lines)?;
         }
         UiMessage::Transition { from, to } => {
             let line = TranscriptLine {
@@ -837,7 +838,7 @@ fn handle_message(
                 continuation: false,
             };
             app.messages.push(line.clone());
-            print_message_and_restore_prompt(stdout, app, ui, vec![line])?;
+            print_message_and_restore_prompt(stdout, app, ui, std::slice::from_ref(&line))?;
         }
         UiMessage::StatusUpdate(status) => {
             let mut next = status;
@@ -1081,11 +1082,11 @@ fn print_message_and_restore_prompt(
     stdout: &mut Stdout,
     app: &App,
     ui: &mut TerminalUi,
-    lines: Vec<TranscriptLine>,
+    lines: &[TranscriptLine],
 ) -> Result<()> {
     clear_live_area(stdout, ui)?;
     queue!(stdout, MoveToColumn(0), Clear(ClearType::UntilNewLine))?;
-    for line in &lines {
+    for line in lines {
         print_transcript_line(stdout, line)?;
     }
     ui.prompt_visible = false;

--- a/src/server/tools/check_gate.rs
+++ b/src/server/tools/check_gate.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::collections::VecDeque;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -104,7 +105,40 @@ fn build_report(commands: &[CommandResult], max_lines: usize, log_path: &Path) -
 }
 
 fn last_n_lines(s: &str, n: usize) -> String {
-    let lines: Vec<&str> = s.lines().collect();
-    let start = lines.len().saturating_sub(n);
-    lines[start..].join("\n")
+    if n == 0 {
+        return String::new();
+    }
+
+    let mut tail = VecDeque::with_capacity(n);
+    for line in s.lines() {
+        if tail.len() == n {
+            tail.pop_front();
+        }
+        tail.push_back(line);
+    }
+    tail.into_iter().collect::<Vec<_>>().join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn last_n_lines_returns_only_tail() {
+        let input = "one\ntwo\nthree\nfour";
+
+        assert_eq!(last_n_lines(input, 2), "three\nfour");
+    }
+
+    #[test]
+    fn last_n_lines_handles_longer_limit() {
+        let input = "one\ntwo";
+
+        assert_eq!(last_n_lines(input, 10), "one\ntwo");
+    }
+
+    #[test]
+    fn last_n_lines_zero_limit_is_empty() {
+        assert_eq!(last_n_lines("one\ntwo", 0), "");
+    }
 }


### PR DESCRIPTION
## Summary
  - Updated project docs (README.md, AGENTS.md, CLAUDE.md) to match current HQ commands, runtime files, agent adapter layout, and reset/check behavior.
  - Added small performance improvements:
      - cache selected spec/milestone display resolution in the HQ state watcher;
      - avoid extra TUI transcript cloning;
      - keep only the needed tail lines when building check failure summaries.
  - Improved TUI status refresh so periodic state updates redraw only the status line instead of repainting the input prompt.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Enhancement
- [x] Performance
- [ ] Documentation
- [ ] Refactor
- [ ] Security
- [ ] Breaking change

## Workflow impact (if applicable)
Does this change affect the Supervisor → Executor → Reviewer flow?

- [x] No impact
- [ ] Minor change (does not alter lifecycle semantics)
- [ ] Changes behavior of an existing step
- [ ] Introduces new state/transition

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)

## Notes for reviewers
Anything you'd like reviewers to pay extra attention to?
